### PR TITLE
Augment target audience: support net7.0

### DIFF
--- a/src/Oxpecker.ViewEngine/Oxpecker.ViewEngine.fsproj
+++ b/src/Oxpecker.ViewEngine/Oxpecker.ViewEngine.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <PackageId>Oxpecker.ViewEngine</PackageId>
         <Title>Oxpecker.ViewEngine</Title>
         <RootNamespace>Oxpecker.ViewEngine</RootNamespace>

--- a/src/Oxpecker/Oxpecker.fsproj
+++ b/src/Oxpecker/Oxpecker.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <PackageId>Oxpecker</PackageId>
         <Title>Oxpecker</Title>
         <RootNamespace>Oxpecker</RootNamespace>


### PR DESCRIPTION
Quoting your Medium article:

> I don’t believe that people will switch the framework in their
> existing projects anyway, and for the new projects newer .NET is
> an obvious choice.

Obvious choice? Well, is newer always better? In general, yes, but this is not a black&white scenario. Newer is good, especially if you are starting from scratch, but how new? bleeding-edge new? pre-release new? nightly new? There's many shades of grey here.

And that's why we have qualifiers for releases: for example, Ubuntu 23.04 might be newer than Ubuntu 22.04, however the latter is an "LTS" release and that's why many business stick to it and only upgrade to the next LTS release: so that they upgrade to a more battle-tested platform and avoid all the bugs (that other early adopters can catch on behalf of them).

And this is why changing the target framework here from net8.0 to net7.0 might increase your target audience: there may be sysadmins out there that are hesitant, or simply cannot, upgrade to .net8.0 yet. An example is that if you install Ubuntu22.04.3 (LTS) today and try to install the package `dotnet8` (with `apt`), it doesn't exist. However, `dotnet7` does exist.

So why limit Oxpecker to only early adopters that can consume net8.0 today instead of increasing the target audience to potential adopters by supporting net7.0? Especially given that Oxpecker isn't really making use of any feature of .net8.0 so it is essentially not a requirement. Let the consumers of your library update their .net runtimes at their own pace.