### PR TITLE
Tiny memory optimization

### DIFF
--- a/src/Oxpecker/HttpContextExtensions.fs
+++ b/src/Oxpecker/HttpContextExtensions.fs
@@ -235,7 +235,7 @@ type HttpContextExtensions() =
                     bytes.LongLength
             ctx.Response.ContentLength <- contentLength
         if ctx.Request.Method <> HttpMethods.Head then
-            ctx.Response.Body.WriteAsync(bytes, 0, bytes.Length)
+            ctx.Response.Body.WriteAsync(bytes.AsMemory(0, bytes.Length)).AsTask()
         else
             Task.CompletedTask
 

--- a/tests/PerfTest/JSON.fs
+++ b/tests/PerfTest/JSON.fs
@@ -96,7 +96,7 @@ module SpanJson =
                         let buffer = JsonSerializer.Generic.Utf8.SerializeToArrayPool<_>(value)
                         ctx.Response.Headers.ContentLength <- buffer.Count
                         if ctx.Request.Method <> HttpMethods.Head then
-                            do! ctx.Response.Body.WriteAsync(buffer)
+                            do! ctx.Response.Body.WriteAsync(buffer.AsMemory(0, buffer.Count))
                         ArrayPool<byte>.Shared.Return(buffer.Array)
                     }
 


### PR DESCRIPTION
CA1835: Prefer the memory-based overloads of ReadAsync/WriteAsync methods in stream-based classes

https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1835

That actually returns ValueTask instead of Task, but I just used `.AsTask()` instead of larger refactoring.