### PR TITLE
feat: minimize Fable output (requires Fable 4.23.0)

### DIFF
--- a/examples/EmptySolid/.config/dotnet-tools.json
+++ b/examples/EmptySolid/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "4.22.0",
+      "version": "4.23.0",
       "commands": [
         "fable"
       ],

--- a/examples/TodoList/.config/dotnet-tools.json
+++ b/examples/TodoList/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "4.22.0",
+      "version": "4.23.0",
       "commands": [
         "fable"
       ],

--- a/src/Oxpecker.Solid/Aria.fs
+++ b/src/Oxpecker.Solid/Aria.fs
@@ -1,109 +1,162 @@
 namespace Oxpecker.Solid
 
+open Fable.Core
+
 module Aria =
 
     type HtmlTag with
         // aria role
+        [<Erase>]
         member this.role
             with set (value: string) = ()
         // aria attributes
+        [<Erase>]
         member this.ariaActiveDescendant
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaAtomic
             with set (value: bool) = ()
+        [<Erase>]
         member this.ariaAutoComplete
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaBrailleLabel
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaBrailleRoleDescription
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaBusy
             with set (value: bool) = ()
+        [<Erase>]
         member this.ariaChecked
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaColCount
             with set (value: int) = ()
+        [<Erase>]
         member this.ariaColIndex
             with set (value: int) = ()
+        [<Erase>]
         member this.ariaColIndexText
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaControls
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaCurrent
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaDescribedBy
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaDescription
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaDetails
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaDisabled
             with set (value: bool) = ()
+        [<Erase>]
         member this.ariaErrorMessage
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaExpanded
             with set (value: bool) = ()
+        [<Erase>]
         member this.ariaFlowTo
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaHasPopup
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaHidden
             with set (value: bool) = ()
+        [<Erase>]
         member this.ariaInvalid
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaKeyShortcuts
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaLabel
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaLabelledBy
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaLevel
             with set (value: int) = ()
+        [<Erase>]
         member this.ariaLive
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaModal
             with set (bool: bool) = ()
+        [<Erase>]
         member this.ariaMultiLine
             with set (bool: bool) = ()
+        [<Erase>]
         member this.ariaMultiSelectable
             with set (bool: bool) = ()
+        [<Erase>]
         member this.ariaOrientation
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaOwns
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaPlaceholder
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaPosInSet
             with set (value: int) = ()
+        [<Erase>]
         member this.ariaPressed
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaReadOnly
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaRelevant
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaRequired
             with set (bool: bool) = ()
+        [<Erase>]
         member this.ariaRoleDescription
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaRowCount
             with set (value: int) = ()
+        [<Erase>]
         member this.ariaRowIndex
             with set (value: int) = ()
+        [<Erase>]
         member this.ariaRowIndexText
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaRowSpan
             with set (value: int) = ()
+        [<Erase>]
         member this.ariaSelected
             with set (bool: bool) = ()
+        [<Erase>]
         member this.ariaSetSize
             with set (value: int) = ()
+        [<Erase>]
         member this.ariaSort
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaValueMax
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaValueMin
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaValueNow
             with set (value: string) = ()
+        [<Erase>]
         member this.ariaValueText
             with set (value: string) = ()

--- a/src/Oxpecker.Solid/Builder.fs
+++ b/src/Oxpecker.Solid/Builder.fs
@@ -1,11 +1,13 @@
 ﻿namespace Oxpecker.Solid
 
 open System.Runtime.CompilerServices
+open Fable.Core
 
 [<AutoOpen>]
 module Builder =
 
     [<Struct>]
+    [<Erase>]
     type HtmlAttribute = { Name: string; Value: obj }
 
     type HtmlElement = interface end
@@ -14,11 +16,16 @@ module Builder =
     type HtmlContainer =
         inherit HtmlElement
 
+    [<Erase>]
     type RegularNode() =
         interface HtmlTag
         interface HtmlContainer
+
+    [<Erase>]
     type FragmentNode() =
         interface HtmlContainer
+
+    [<Erase>]
     type VoidNode() =
         interface HtmlTag
 
@@ -42,8 +49,9 @@ module Builder =
 
         member inline _.Yield(text: int) : HtmlContainerFun = fun cont -> ignore text
 
+    [<Erase>]
     type HtmlContainerExtensions =
-        [<Extension>]
+        [<Extension; Erase>]
         static member Run(this: #HtmlContainer, runExpr: HtmlContainerFun) =
             runExpr this
             this

--- a/src/Oxpecker.Solid/IdeTweaks.fs
+++ b/src/Oxpecker.Solid/IdeTweaks.fs
@@ -1,7 +1,9 @@
 namespace JetBrains.Annotations
 
 open System
+open Fable.Core
 
+[<Erase>]
 type internal InjectedLanguage =
     | CSS = 0
     | HTML = 1
@@ -12,8 +14,12 @@ type internal InjectedLanguage =
 [<AttributeUsage(AttributeTargets.Parameter
                  ||| AttributeTargets.Field
                  ||| AttributeTargets.Property)>]
+[<Erase>]
 type internal LanguageInjectionAttribute(injectedLanguage: InjectedLanguage) =
     inherit Attribute()
+    [<Erase>]
     member x.InjectedLanguage = injectedLanguage
+    [<Erase>]
     member val Prefix = "" with get, set
+    [<Erase>]
     member val Suffix = "" with get, set

--- a/src/Oxpecker.Solid/SolidBindings.fs
+++ b/src/Oxpecker.Solid/SolidBindings.fs
@@ -15,317 +15,453 @@ module Bindings =
 
     /// Solid on* event handlers
     type HtmlTag with
+        [<Erase>]
         member this.onClick
             with set (_: MouseEvent -> unit) = ()
+        [<Erase>]
         member this.onDblClick
             with set (_: MouseEvent -> unit) = ()
+        [<Erase>]
         member this.onBlur
             with set (_: FocusEvent -> unit) = ()
+        [<Erase>]
         member this.onFocus
             with set (_: FocusEvent -> unit) = ()
+        [<Erase>]
         member this.onContextMenu
             with set (_: MouseEvent -> unit) = ()
+        [<Erase>]
         member this.onMouseDown
             with set (_: MouseEvent -> unit) = ()
+        [<Erase>]
         member this.onMouseUp
             with set (_: MouseEvent -> unit) = ()
+        [<Erase>]
         member this.onMouseEnter
             with set (_: MouseEvent -> unit) = ()
+        [<Erase>]
         member this.onMouseLeave
             with set (_: MouseEvent -> unit) = ()
+        [<Erase>]
         member this.onMouseOver
             with set (_: MouseEvent -> unit) = ()
+        [<Erase>]
         member this.onMouseOut
             with set (_: MouseEvent -> unit) = ()
+        [<Erase>]
         member this.onMouseMove
             with set (_: MouseEvent -> unit) = ()
+        [<Erase>]
         member this.onWheel
             with set (_: WheelEvent -> unit) = ()
+        [<Erase>]
         member this.onKeyDown
             with set (_: KeyboardEvent -> unit) = ()
+        [<Erase>]
         member this.onKeyUp
             with set (_: KeyboardEvent -> unit) = ()
+        [<Erase>]
         member this.onKeyPress
             with set (_: KeyboardEvent -> unit) = ()
+        [<Erase>]
         member this.onDrag
             with set (_: DragEvent -> unit) = ()
+        [<Erase>]
         member this.onDragEnd
             with set (_: DragEvent -> unit) = ()
+        [<Erase>]
         member this.onDragEnter
             with set (_: DragEvent -> unit) = ()
+        [<Erase>]
         member this.onDragLeave
             with set (_: DragEvent -> unit) = ()
+        [<Erase>]
         member this.onDragOver
             with set (_: DragEvent -> unit) = ()
+        [<Erase>]
         member this.onDragStart
             with set (_: DragEvent -> unit) = ()
+        [<Erase>]
         member this.onDrop
             with set (_: DragEvent -> unit) = ()
+        [<Erase>]
         member this.onScroll
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onPointerDown
             with set (_: PointerEvent -> unit) = ()
+        [<Erase>]
         member this.onPointerMove
             with set (_: PointerEvent -> unit) = ()
+        [<Erase>]
         member this.onPointerUp
             with set (_: PointerEvent -> unit) = ()
+        [<Erase>]
         member this.onPointerCancel
             with set (_: PointerEvent -> unit) = ()
+        [<Erase>]
         member this.onPointerEnter
             with set (_: PointerEvent -> unit) = ()
+        [<Erase>]
         member this.onPointerLeave
             with set (_: PointerEvent -> unit) = ()
+        [<Erase>]
         member this.onPointerOver
             with set (_: PointerEvent -> unit) = ()
+        [<Erase>]
         member this.onPointerOut
             with set (_: PointerEvent -> unit) = ()
+        [<Erase>]
         member this.onGotPointerCapture
             with set (_: PointerEvent -> unit) = ()
+        [<Erase>]
         member this.onLostPointerCapture
             with set (_: PointerEvent -> unit) = ()
+        [<Erase>]
         member this.onAnimationStart
             with set (_: AnimationEvent -> unit) = ()
+        [<Erase>]
         member this.onAnimationEnd
             with set (_: AnimationEvent -> unit) = ()
+        [<Erase>]
         member this.onAnimationIteration
             with set (_: AnimationEvent -> unit) = ()
+        [<Erase>]
         member this.onTransitionEnd
             with set (_: TransitionEvent -> unit) = ()
+        [<Erase>]
         member this.onTransitionRun
             with set (_: TransitionEvent -> unit) = ()
+        [<Erase>]
         member this.onTransitionStart
             with set (_: TransitionEvent -> unit) = ()
+        [<Erase>]
         member this.onTransitionCancel
             with set (_: TransitionEvent -> unit) = ()
+        [<Erase>]
         member this.onTouchStart
             with set (_: TouchEvent -> unit) = ()
+        [<Erase>]
         member this.onTouchMove
             with set (_: TouchEvent -> unit) = ()
+        [<Erase>]
         member this.onTouchEnd
             with set (_: TouchEvent -> unit) = ()
+        [<Erase>]
         member this.onTouchCancel
             with set (_: TouchEvent -> unit) = ()
+        [<Erase>]
         member this.onCopy
             with set (_: ClipboardEvent -> unit) = ()
+        [<Erase>]
         member this.onCut
             with set (_: ClipboardEvent -> unit) = ()
+        [<Erase>]
         member this.onPaste
             with set (_: ClipboardEvent -> unit) = ()
+        [<Erase>]
         member this.onCompositionStart
             with set (_: CompositionEvent -> unit) = ()
+        [<Erase>]
         member this.onCompositionEnd
             with set (_: CompositionEvent -> unit) = ()
+        [<Erase>]
         member this.onCompositionUpdate
             with set (_: CompositionEvent -> unit) = ()
+        [<Erase>]
         member this.onFocusIn
             with set (_: FocusEvent -> unit) = ()
+        [<Erase>]
         member this.onFocusOut
             with set (_: FocusEvent -> unit) = ()
+        [<Erase>]
         member this.onEncrypted
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onDragExit
             with set (_: DragEvent -> unit) = ()
 
     type RegularNode with
+        [<Erase>]
         member this.textContent
             with set (value: string) = ()
+        [<Erase>]
         member this.innerHTML
             with set (value: string) = ()
 
     type form with
+        [<Erase>]
         member this.onSubmit
             with set (_: SubmitEvent -> unit) = ()
+        [<Erase>]
         member this.onReset
             with set (_: Event -> unit) = ()
 
     type input with
+        [<Erase>]
         member this.onChange
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onInvalid
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onInput
             with set (_: InputEvent -> unit) = ()
+        [<Erase>]
         member this.onSelect
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onError
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onLoad
             with set (_: Event -> unit) = ()
 
     type select with
+        [<Erase>]
         member this.onChange
             with set (_: Event -> unit) = ()
 
     type textarea with
+        [<Erase>]
         member this.onChange
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onInput
             with set (_: InputEvent -> unit) = ()
+        [<Erase>]
         member this.onSelect
             with set (_: Event -> unit) = ()
 
     type details with
+        [<Erase>]
         member this.onToggle
             with set (_: ToggleEvent -> unit) = ()
 
     type img with
+        [<Erase>]
         member this.onError
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onLoad
             with set (_: Event -> unit) = ()
 
     type object' with
+        [<Erase>]
         member this.onError
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onLoad
             with set (_: Event -> unit) = ()
 
     type link with
+        [<Erase>]
         member this.onError
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onLoad
             with set (_: Event -> unit) = ()
 
     type script with
+        [<Erase>]
         member this.onError
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onLoad
             with set (_: Event -> unit) = ()
 
     type style with
+        [<Erase>]
         member this.onError
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onLoad
             with set (_: Event -> unit) = ()
 
     type body with
+        [<Erase>]
         member this.onLoad
             with set (_: Event -> unit) = ()
 
     type iframe with
+        [<Erase>]
         member this.onLoad
             with set (_: Event -> unit) = ()
 
     type embed with
+        [<Erase>]
         member this.onLoad
             with set (_: Event -> unit) = ()
 
     type audio with
+        [<Erase>]
         member this.onError
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onPlay
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onPause
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onEnded
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onVolumeChange
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onSeeked
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onSeeking
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onTimeUpdate
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onDurationChange
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onRateChange
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onCanPlay
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onCanPlayThrough
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onStalled
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onWaiting
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onEmptied
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onLoadedData
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onLoadedMetadata
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onLoadStart
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onProgress
             with set (_: ProgressEvent -> unit) = ()
+        [<Erase>]
         member this.onSuspend
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onAbort
             with set (_: Event -> unit) = ()
 
     type video with
+        [<Erase>]
         member this.onError
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onPlay
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onPause
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onEnded
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onVolumeChange
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onSeeked
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onSeeking
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onTimeUpdate
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onDurationChange
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onRateChange
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onCanPlay
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onCanPlayThrough
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onStalled
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onWaiting
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onEmptied
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onLoadedData
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onLoadedMetadata
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onLoadStart
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onProgress
             with set (_: ProgressEvent -> unit) = ()
+        [<Erase>]
         member this.onSuspend
             with set (_: Event -> unit) = ()
+        [<Erase>]
         member this.onAbort
             with set (_: Event -> unit) = ()
 
+    [<Erase>]
     type For<'T>() =
         interface HtmlElement
+        [<Erase>]
         member this.each
             with set (value: 'T[]) = ()
         member inline _.Zero() : HtmlContainerFun = ignore
         member inline _.Yield(value: 'T -> Accessor<int> -> #HtmlElement) : HtmlContainerFun = fun cont -> ignore value
 
+    [<Erase>]
     type Index<'T>() =
         interface HtmlElement
+        [<Erase>]
         member this.each
             with set (value: 'T[]) = ()
         member inline _.Zero() : HtmlContainerFun = ignore
         member inline _.Yield(value: Accessor<'T> -> int -> #HtmlElement) : HtmlContainerFun = fun cont -> ignore value
 
+    [<Erase>]
     type Show() =
         interface HtmlContainer
+        [<Erase>]
         member this.when'
             with set (value: bool) = ()
+        [<Erase>]
         member this.fallback
             with set (value: HtmlElement) = ()
 
+    [<Erase>]
     type Match() =
         interface HtmlContainer
+        [<Erase>]
         member this.when'
             with set (value: bool) = ()
 
+    [<Erase>]
     type Switch() =
         interface HtmlElement
+        [<Erase>]
         member this.fallback
             with set (value: HtmlElement) = ()
         member inline _.Combine
@@ -338,45 +474,57 @@ module Bindings =
         member inline _.Zero() : HtmlContainerFun = ignore
         member inline _.Yield(value: Match) : HtmlContainerFun = fun cont -> ignore value
 
+    [<Erase>]
     type Suspense() =
         interface HtmlContainer
+        [<Erase>]
         member this.fallback
             with set (value: HtmlElement) = ()
 
+    [<Erase>]
     type SuspenseList() =
         interface HtmlContainer
+        [<Erase>]
         member this.revealOrder
             with set (value: string) = ()
+        [<Erase>]
         member this.tail
             with set (value: string) = ()
+        [<Erase>]
         member this.fallback
             with set (value: HtmlElement) = ()
 
+    [<Erase>]
     type Portal() =
         interface HtmlContainer
+        [<Erase>]
         member this.mount
             with set (value: Element) = ()
+        [<Erase>]
         member this.useShadow
             with set (value: bool) = ()
 
+    [<Erase>]
     type ErrorBoundary() =
         interface HtmlContainer
+        [<Erase>]
         member this.fallback
             with set (value: HtmlElement) = ()
 
+    [<Erase>]
     type Extensions =
 
-        [<Extension>]
+        [<Extension; Erase>]
         static member Run(this: For<'T>, runExpr: HtmlContainerFun) =
             runExpr Unchecked.defaultof<_>
             this
 
-        [<Extension>]
+        [<Extension; Erase>]
         static member Run(this: Index<'T>, runExpr: HtmlContainerFun) =
             runExpr Unchecked.defaultof<_>
             this
 
-        [<Extension>]
+        [<Extension; Erase>]
         static member Run(this: Switch, runExpr: HtmlContainerFun) =
             runExpr Unchecked.defaultof<_>
             this
@@ -443,21 +591,22 @@ module Bindings =
             /// Access more convenient way of updating store items
             member this.Path = SolidStorePath<'T, 'T>(this, [||])
 
-    [<Runtime.CompilerServices.Extension>]
+    [<Extension; Erase>]
     type SolidStorePathExtensions =
 
         /// Select store item by index
-        [<Runtime.CompilerServices.Extension>]
+        [<Extension; Erase>]
         static member inline Item(this: SolidStorePath<'T, 'Value array>, index: int) =
             SolidStorePath<'T, 'Value>(this.Setter, Array.append this.Path [| index |])
 
         /// Select store item by predicate
-        [<Runtime.CompilerServices.Extension>]
+        [<Extension; Erase>]
         static member inline Find(this: SolidStorePath<'T, 'Value array>, predicate: 'Value -> bool) =
             SolidStorePath<'T, 'Value>(this.Setter, Array.append this.Path [| predicate |])
 
 
 [<AutoOpen>]
+[<Erase>]
 type Bindings =
 
     [<ImportMember("solid-js/web")>]

--- a/src/Oxpecker.Solid/SolidRouterBindings.fs
+++ b/src/Oxpecker.Solid/SolidRouterBindings.fs
@@ -139,43 +139,56 @@ module Bindings =
     type PreloadData [<ParamObject; Emit("$0")>] (preloadData: bool) =
         member val preloadData: bool = jsNative with get, set
 
+    [<Erase>]
     type Extensions =
-        [<Extension>]
+        [<Extension; Erase>]
         static member Run(this: Router, runExpr: HtmlContainerFun) =
             runExpr Unchecked.defaultof<_>
             this
 
-        [<Extension>]
+        [<Extension; Erase>]
         static member Run(this: Route, runExpr: HtmlContainerFun) =
             runExpr Unchecked.defaultof<_>
             this
 
+    [<Erase>]
     type A() =
         inherit RegularNode()
+        [<Erase>]
         member this.href
             with set (value: string) = ()
+        [<Erase>]
         member this.noScroll
             with set (value: bool) = ()
+        [<Erase>]
         member this.replace
             with set (value: bool) = ()
+        [<Erase>]
         member this.state
             with set (value: obj) = ()
+        [<Erase>]
         member this.activeClass
             with set (value: string) = ()
+        [<Erase>]
         member this.inactiveClass
             with set (value: string) = ()
+        [<Erase>]
         member this.end'
             with set (value: bool) = ()
 
+    [<Erase>]
     type Navigate() =
         inherit RegularNode()
+        [<Erase>]
         member this.href
             with set (value: string) = ()
+        [<Erase>]
         member this.state
             with set (value: obj) = ()
 
 
 [<AutoOpen>]
+[<Erase>]
 type Bindings =
 
     [<ImportMember("@solidjs/router")>]

--- a/src/Oxpecker.Solid/Tags.fs
+++ b/src/Oxpecker.Solid/Tags.fs
@@ -4,799 +4,1156 @@ open System
 open System.Runtime.CompilerServices
 open Browser.Types
 open JetBrains.Annotations
+open Fable.Core
 
 [<AutoOpen>]
 module Tags =
 
     /// Fragment (or template) node, only renders children, not itself
+    [<Erase>]
     type Fragment() =
         inherit FragmentNode()
 
     /// Set of html extensions that keep original type
     [<Extension>]
+    [<Erase>]
     type HtmlElementExtensions =
 
         /// Add an attribute to the element
-        [<Extension>]
+        [<Extension; Erase>]
         static member attr(this: #HtmlTag, name: string, value: string) = this
 
         /// Add event handler to the element through the corresponding attribute
-        [<Extension>]
+        [<Extension; Erase>]
         static member on(this: #HtmlTag, eventName: string, eventHandler: Event -> unit) = this
 
         /// Add data attribute to the element
-        [<Extension>]
+        [<Extension; Erase>]
         static member data(this: #HtmlTag, name: string, value: string) = this
 
         /// Referenced native HTML element
-        [<Extension>]
+        [<Extension; Erase>]
         static member ref(this: #HtmlTag, el: #Element) = this
 
         /// Referenced native HTML element (before connecting to DOM)
-        [<Extension>]
+        [<Extension; Erase>]
         static member ref(this: #HtmlTag, el: #Element -> unit) = this
 
         /// Usage `elem.style(createObj ["color", "green"; "background-color", state.myColor ])`
-        [<Extension>]
+        [<Extension; Erase>]
         static member style'(this: #HtmlTag, styleObj: obj) = this
 
         /// Usage `elem.classList(createObj ["active", true; "disabled", state.disabled ])`
-        [<Extension>]
+        [<Extension; Erase>]
         static member classList(this: #HtmlTag, classListObj: obj) = this
 
         /// Adds or removes attribute without value
-        [<Extension>]
+        [<Extension; Erase>]
         static member bool(this: #HtmlTag, name: string, value: bool) = this
 
     // global attributes
     type HtmlTag with
+        [<Erase>]
         member this.id
             with set (value: string) = ()
+        [<Erase>]
         member this.class'
             with set (value: string) = ()
         [<LanguageInjection(InjectedLanguage.CSS, Prefix = ".x{", Suffix = ";}")>]
+        [<Erase>]
         member this.style
             with set (value: string) = ()
+        [<Erase>]
         member this.lang
             with set (value: string) = ()
+        [<Erase>]
         member this.dir
             with set (value: string) = ()
+        [<Erase>]
         member this.tabindex
             with set (value: int) = ()
+        [<Erase>]
         member this.title
             with set (value: string) = ()
+        [<Erase>]
         member this.accesskey
             with set (value: char) = ()
+        [<Erase>]
         member this.contenteditable
             with set (value: string) = ()
+        [<Erase>]
         member this.draggable
             with set (value: string) = ()
+        [<Erase>]
         member this.enterkeyhint
             with set (value: string) = ()
+        [<Erase>]
         member this.hidden
             with set (value: string) = ()
+        [<Erase>]
         member this.inert
             with set (value: bool) = ()
+        [<Erase>]
         member this.inputmode
             with set (value: string) = ()
+        [<Erase>]
         member this.popover
             with set (value: string) = ()
+        [<Erase>]
         member this.spellcheck
             with set (value: bool) = ()
+        [<Erase>]
         member this.translate
             with set (value: string) = ()
+        [<Erase>]
         member this.autocapitalize
             with set (value: string) = ()
+        [<Erase>]
         member this.is
             with set (value: string) = ()
+        [<Erase>]
         member this.part
             with set (value: string) = ()
+        [<Erase>]
         member this.slot
             with set (value: string) = ()
 
+    [<Erase>]
     type head() =
         inherit RegularNode()
+    [<Erase>]
     type body() =
         inherit RegularNode()
+    [<Erase>]
     type title() =
         inherit RegularNode()
+    [<Erase>]
     type div() =
         inherit RegularNode()
+    [<Erase>]
     type article() =
         inherit RegularNode()
+    [<Erase>]
     type section() =
         inherit RegularNode()
+    [<Erase>]
     type header() =
         inherit RegularNode()
+    [<Erase>]
     type footer() =
         inherit RegularNode()
+    [<Erase>]
     type main() =
         inherit RegularNode()
+    [<Erase>]
     type h1() =
         inherit RegularNode()
+    [<Erase>]
     type h2() =
         inherit RegularNode()
+    [<Erase>]
     type h3() =
         inherit RegularNode()
+    [<Erase>]
     type h4() =
         inherit RegularNode()
+    [<Erase>]
     type h5() =
         inherit RegularNode()
+    [<Erase>]
     type h6() =
         inherit RegularNode()
+    [<Erase>]
     type ul() =
         inherit RegularNode()
+    [<Erase>]
     type ol() =
         inherit RegularNode()
+    [<Erase>]
     type li() =
         inherit RegularNode()
+    [<Erase>]
     type p() =
         inherit RegularNode()
+    [<Erase>]
     type span() =
         inherit RegularNode()
+    [<Erase>]
     type small() =
         inherit RegularNode()
+    [<Erase>]
     type strong() =
         inherit RegularNode()
+    [<Erase>]
     type em() =
         inherit RegularNode()
+    [<Erase>]
     type caption() =
         inherit RegularNode()
+    [<Erase>]
     type nav() =
         inherit RegularNode()
+    [<Erase>]
     type search() =
         inherit RegularNode()
+    [<Erase>]
     type i() =
         inherit RegularNode()
+    [<Erase>]
     type b() =
         inherit RegularNode()
+    [<Erase>]
     type u() =
         inherit RegularNode()
+    [<Erase>]
     type s() =
         inherit RegularNode()
+    [<Erase>]
     type noscript() =
         inherit RegularNode()
+    [<Erase>]
     type code() =
         inherit RegularNode()
+    [<Erase>]
     type pre() =
         inherit RegularNode()
+    [<Erase>]
     type blockquote() =
         inherit RegularNode()
+    [<Erase>]
     type cite() =
         inherit RegularNode()
+    [<Erase>]
     type q() =
         inherit RegularNode()
+    [<Erase>]
     type address() =
         inherit RegularNode()
+    [<Erase>]
     type del() =
         inherit RegularNode()
+    [<Erase>]
     type ins() =
         inherit RegularNode()
+    [<Erase>]
     type abbr() =
         inherit RegularNode()
+    [<Erase>]
     type dfn() =
         inherit RegularNode()
+    [<Erase>]
     type sub() =
         inherit RegularNode()
+    [<Erase>]
     type sup() =
         inherit RegularNode()
+    [<Erase>]
     type template() =
         inherit RegularNode()
 
+    [<Erase>]
     type br() =
         inherit VoidNode()
+    [<Erase>]
     type hr() =
         inherit VoidNode()
 
+    [<Erase>]
     type a() =
         inherit RegularNode()
+        [<Erase>]
         member this.href
             with set (value: string) = ()
+        [<Erase>]
         member this.hreflang
             with set (value: string) = ()
+        [<Erase>]
         member this.rel
             with set (value: string) = ()
+        [<Erase>]
         member this.target
             with set (value: string) = ()
+        [<Erase>]
         member this.download
             with set (value: string) = ()
+        [<Erase>]
         member this.ping
             with set (value: string) = ()
+        [<Erase>]
         member this.type'
             with set (value: string) = ()
+        [<Erase>]
         member this.referrerpolicy
             with set (value: string) = ()
 
+    [<Erase>]
     type base'() =
         inherit VoidNode()
+        [<Erase>]
         member this.href
             with set (value: string) = ()
+        [<Erase>]
         member this.target
             with set (value: string) = ()
 
+    [<Erase>]
     type img() =
         inherit VoidNode()
+        [<Erase>]
         member this.src
             with set (value: string) = ()
+        [<Erase>]
         member this.alt
             with set (value: string) = ()
+        [<Erase>]
         member this.width
             with set (value: int) = ()
+        [<Erase>]
         member this.height
             with set (value: int) = ()
+        [<Erase>]
         member this.srcset
             with set (value: string) = ()
+        [<Erase>]
         member this.referrerpolicy
             with set (value: string) = ()
+        [<Erase>]
         member this.crossorigin
             with set (value: string) = ()
+        [<Erase>]
         member this.sizes
             with set (value: string) = ()
+        [<Erase>]
         member this.usemap
             with set (value: string) = ()
+        [<Erase>]
         member this.ismap
             with set (value: bool) = ()
+        [<Erase>]
         member this.decoding
             with set (value: string) = ()
+        [<Erase>]
         member this.loading
             with set (value: string) = ()
+        [<Erase>]
         member this.fetchpriority
             with set (value: string) = ()
+        [<Erase>]
         member this.elementtiming
             with set (value: string) = ()
 
+    [<Erase>]
     type form() =
         inherit RegularNode()
+        [<Erase>]
         member this.action
             with set (value: string) = ()
+        [<Erase>]
         member this.method
             with set (value: string) = ()
+        [<Erase>]
         member this.enctype
             with set (value: string) = ()
+        [<Erase>]
         member this.target
             with set (value: string) = ()
+        [<Erase>]
         member this.acceptCharset
             with set (value: string) = ()
+        [<Erase>]
         member this.autocomplete
             with set (value: string) = ()
+        [<Erase>]
         member this.name
             with set (value: string) = ()
+        [<Erase>]
         member this.novalidate
             with set (value: bool) = ()
+        [<Erase>]
         member this.rel
             with set (value: string) = ()
 
+    [<Erase>]
     type script() =
         inherit RegularNode()
+        [<Erase>]
         member this.src
             with set (value: string) = ()
+        [<Erase>]
         member this.type'
             with set (value: string) = ()
+        [<Erase>]
         member this.async
             with set (value: bool) = ()
+        [<Erase>]
         member this.defer
             with set (value: bool) = ()
+        [<Erase>]
         member this.integrity
             with set (value: string) = ()
+        [<Erase>]
         member this.crossorigin
             with set (value: string) = ()
+        [<Erase>]
         member this.nomodule
             with set (value: bool) = ()
+        [<Erase>]
         member this.nonce
             with set (value: string) = ()
+        [<Erase>]
         member this.referrerpolicy
             with set (value: string) = ()
 
+    [<Erase>]
     type link() =
         inherit VoidNode()
+        [<Erase>]
         member this.rel
             with set (value: string) = ()
+        [<Erase>]
         member this.href
             with set (value: string) = ()
+        [<Erase>]
         member this.type'
             with set (value: string) = ()
+        [<Erase>]
         member this.media
             with set (value: string) = ()
+        [<Erase>]
         member this.as'
             with set (value: string) = ()
+        [<Erase>]
         member this.sizes
             with set (value: string) = ()
+        [<Erase>]
         member this.crossorigin
             with set (value: string) = ()
+        [<Erase>]
         member this.integrity
             with set (value: string) = ()
+        [<Erase>]
         member this.referrerpolicy
             with set (value: string) = ()
+        [<Erase>]
         member this.disabled
             with set (value: bool) = ()
+        [<Erase>]
         member this.hreflang
             with set (value: string) = ()
+        [<Erase>]
         member this.imagesizes
             with set (value: string) = ()
+        [<Erase>]
         member this.imagesrcset
             with set (value: string) = ()
+        [<Erase>]
         member this.title
             with set (value: string) = ()
 
+    [<Erase>]
     type html() =
         inherit RegularNode()
+        [<Erase>]
         member this.xmlns
             with set (value: string) = ()
 
+    [<Erase>]
     type meta() =
         inherit VoidNode()
+        [<Erase>]
         member this.name
             with set (value: string) = ()
+        [<Erase>]
         member this.content
             with set (value: string) = ()
+        [<Erase>]
         member this.charset
             with set (value: string) = ()
+        [<Erase>]
         member this.httpEquiv
             with set (value: string) = ()
 
+    [<Erase>]
     type input() =
         inherit VoidNode()
+        [<Erase>]
         member this.type'
             with set (value: string) = ()
+        [<Erase>]
         member this.name
             with set (value: string) = ()
+        [<Erase>]
         member this.value
             with set (value: string) = ()
+        [<Erase>]
         member this.placeholder
             with set (value: string) = ()
+        [<Erase>]
         member this.required
             with set (value: bool) = ()
+        [<Erase>]
         member this.autofocus
             with set (value: bool) = ()
+        [<Erase>]
         member this.autocomplete
             with set (value: string) = ()
+        [<Erase>]
         member this.min
             with set (value: string) = ()
+        [<Erase>]
         member this.max
             with set (value: string) = ()
+        [<Erase>]
         member this.step
             with set (value: string) = ()
+        [<Erase>]
         member this.pattern
             with set (value: string) = ()
+        [<Erase>]
         member this.readonly
             with set (value: bool) = ()
+        [<Erase>]
         member this.disabled
             with set (value: bool) = ()
+        [<Erase>]
         member this.multiple
             with set (value: bool) = ()
+        [<Erase>]
         member this.accept
             with set (value: string) = ()
+        [<Erase>]
         member this.list
             with set (value: string) = ()
+        [<Erase>]
         member this.maxlength
             with set (value: int) = ()
+        [<Erase>]
         member this.minlength
             with set (value: int) = ()
+        [<Erase>]
         member this.size
             with set (value: int) = ()
+        [<Erase>]
         member this.src
             with set (value: string) = ()
+        [<Erase>]
         member this.width
             with set (value: int) = ()
+        [<Erase>]
         member this.height
             with set (value: int) = ()
+        [<Erase>]
         member this.alt
             with set (value: string) = ()
+        [<Erase>]
         member this.checked'
             with set (value: bool) = ()
+        [<Erase>]
         member this.dirname
             with set (value: string) = ()
+        [<Erase>]
         member this.form
             with set (value: string) = ()
+        [<Erase>]
         member this.formaction
             with set (value: string) = ()
+        [<Erase>]
         member this.formenctype
             with set (value: string) = ()
+        [<Erase>]
         member this.formmethod
             with set (value: string) = ()
+        [<Erase>]
         member this.formnovalidate
             with set (value: bool) = ()
+        [<Erase>]
         member this.formtarget
             with set (value: string) = ()
+        [<Erase>]
         member this.inputmode
             with set (value: string) = ()
+        [<Erase>]
         member this.capture
             with set (value: string) = ()
 
+    [<Erase>]
     type output() =
         inherit RegularNode()
+        [<Erase>]
         member this.for'
             with set (value: string) = ()
+        [<Erase>]
         member this.form
             with set (value: string) = ()
+        [<Erase>]
         member this.name
             with set (value: string) = ()
 
+    [<Erase>]
     type textarea() =
         inherit RegularNode()
+        [<Erase>]
         member this.name
             with set (value: string) = ()
+        [<Erase>]
         member this.placeholder
             with set (value: string) = ()
+        [<Erase>]
         member this.required
             with set (value: bool) = ()
+        [<Erase>]
         member this.autofocus
             with set (value: bool) = ()
+        [<Erase>]
         member this.autocomplete
             with set (value: string) = ()
+        [<Erase>]
         member this.readonly
             with set (value: bool) = ()
+        [<Erase>]
         member this.disabled
             with set (value: bool) = ()
+        [<Erase>]
         member this.rows
             with set (value: int) = ()
+        [<Erase>]
         member this.cols
             with set (value: int) = ()
+        [<Erase>]
         member this.wrap
             with set (value: string) = ()
+        [<Erase>]
         member this.maxlength
             with set (value: int) = ()
+        [<Erase>]
         member this.minlength
             with set (value: int) = ()
+        [<Erase>]
         member this.dirname
             with set (value: string) = ()
+        [<Erase>]
         member this.form
             with set (value: string) = ()
 
 
+    [<Erase>]
     type button() =
         inherit RegularNode()
+        [<Erase>]
         member this.type'
             with set (value: string) = ()
+        [<Erase>]
         member this.name
             with set (value: string) = ()
+        [<Erase>]
         member this.value
             with set (value: string) = ()
+        [<Erase>]
         member this.disabled
             with set (value: bool) = ()
+        [<Erase>]
         member this.autofocus
             with set (value: bool) = ()
+        [<Erase>]
         member this.form
             with set (value: string) = ()
+        [<Erase>]
         member this.formaction
             with set (value: string) = ()
+        [<Erase>]
         member this.formenctype
             with set (value: string) = ()
+        [<Erase>]
         member this.formmethod
             with set (value: string) = ()
+        [<Erase>]
         member this.formnovalidate
             with set (value: bool) = ()
+        [<Erase>]
         member this.formtarget
             with set (value: string) = ()
+        [<Erase>]
         member this.popovertarget
             with set (value: string) = ()
+        [<Erase>]
         member this.popovertargetaction
             with set (value: string) = ()
 
+    [<Erase>]
     type select() =
         inherit RegularNode()
+        [<Erase>]
         member this.name
             with set (value: string) = ()
+        [<Erase>]
         member this.required
             with set (value: bool) = ()
+        [<Erase>]
         member this.autofocus
             with set (value: bool) = ()
+        [<Erase>]
         member this.autocomplete
             with set (value: string) = ()
+        [<Erase>]
         member this.disabled
             with set (value: bool) = ()
+        [<Erase>]
         member this.multiple
             with set (value: bool) = ()
+        [<Erase>]
         member this.size
             with set (value: int) = ()
+        [<Erase>]
         member this.form
             with set (value: string) = ()
 
+    [<Erase>]
     type option() =
         inherit RegularNode()
+        [<Erase>]
         member this.value
             with set (value: string) = ()
+        [<Erase>]
         member this.selected
             with set (value: bool) = ()
+        [<Erase>]
         member this.disabled
             with set (value: bool) = ()
+        [<Erase>]
         member this.label
             with set (value: string) = ()
 
+    [<Erase>]
     type optgroup() =
         inherit RegularNode()
+        [<Erase>]
         member this.label
             with set (value: string) = ()
+        [<Erase>]
         member this.disabled
             with set (value: bool) = ()
 
+    [<Erase>]
     type label() =
         inherit RegularNode()
+        [<Erase>]
         member this.for'
             with set (value: string) = ()
 
+    [<Erase>]
     type style() =
         inherit RegularNode()
+        [<Erase>]
         member this.type'
             with set (value: string) = ()
+        [<Erase>]
         member this.media
             with set (value: string) = ()
 
+    [<Erase>]
     type iframe() =
         inherit RegularNode()
+        [<Erase>]
         member this.src
             with set (value: string) = ()
+        [<Erase>]
         member this.name
             with set (value: string) = ()
+        [<Erase>]
         member this.sandbox
             with set (value: string) = ()
+        [<Erase>]
         member this.width
             with set (value: int) = ()
+        [<Erase>]
         member this.height
             with set (value: int) = ()
+        [<Erase>]
         member this.allow
             with set (value: string) = ()
+        [<Erase>]
         member this.loading
             with set (value: string) = ()
+        [<Erase>]
         member this.referrerpolicy
             with set (value: string) = ()
+        [<Erase>]
         member this.srcdoc
             with set (value: string) = ()
 
+    [<Erase>]
     type video() =
         inherit RegularNode()
+        [<Erase>]
         member this.src
             with set (value: string) = ()
+        [<Erase>]
         member this.poster
             with set (value: string) = ()
+        [<Erase>]
         member this.autoplay
             with set (value: bool) = ()
+        [<Erase>]
         member this.controls
             with set (value: bool) = ()
+        [<Erase>]
         member this.playsinline
             with set (value: bool) = ()
+        [<Erase>]
         member this.controlsList
             with set (value: string) = ()
+        [<Erase>]
         member this.crossorigin
             with set (value: string) = ()
+        [<Erase>]
         member this.loop
             with set (value: bool) = ()
+        [<Erase>]
         member this.muted
             with set (value: bool) = ()
+        [<Erase>]
         member this.width
             with set (value: int) = ()
+        [<Erase>]
         member this.height
             with set (value: int) = ()
+        [<Erase>]
         member this.preload
             with set (value: string) = ()
+        [<Erase>]
         member this.disableremoteplayback
             with set (value: bool) = ()
+        [<Erase>]
         member this.disablepictureinpicture
             with set (value: bool) = ()
 
+    [<Erase>]
     type audio() =
         inherit RegularNode()
+        [<Erase>]
         member this.src
             with set (value: string) = ()
+        [<Erase>]
         member this.autoplay
             with set (value: bool) = ()
+        [<Erase>]
         member this.controls
             with set (value: bool) = ()
+        [<Erase>]
         member this.controlsList
             with set (value: string) = ()
+        [<Erase>]
         member this.crossorigin
             with set (value: string) = ()
+        [<Erase>]
         member this.preload
             with set (value: string) = ()
+        [<Erase>]
         member this.loop
             with set (value: bool) = ()
+        [<Erase>]
         member this.muted
             with set (value: bool) = ()
+        [<Erase>]
         member this.disableremoteplayback
             with set (value: bool) = ()
 
+    [<Erase>]
     type source() =
         inherit VoidNode()
+        [<Erase>]
         member this.src
             with set (value: string) = ()
+        [<Erase>]
         member this.type'
             with set (value: string) = ()
+        [<Erase>]
         member this.media
             with set (value: string) = ()
+        [<Erase>]
         member this.sizes
             with set (value: string) = ()
+        [<Erase>]
         member this.srcset
             with set (value: string) = ()
 
+    [<Erase>]
     type canvas() =
         inherit RegularNode()
+        [<Erase>]
         member this.width
             with set (value: int) = ()
+        [<Erase>]
         member this.height
             with set (value: int) = ()
 
+    [<Erase>]
     type object'() =
         inherit RegularNode()
+        [<Erase>]
         member this.data
             with set (value: string) = ()
+        [<Erase>]
         member this.type'
             with set (value: string) = ()
+        [<Erase>]
         member this.width
             with set (value: int) = ()
+        [<Erase>]
         member this.height
             with set (value: int) = ()
 
+    [<Erase>]
     type param() =
         inherit VoidNode()
+        [<Erase>]
         member this.name
             with set (value: string) = ()
+        [<Erase>]
         member this.value
             with set (value: string) = ()
 
+    [<Erase>]
     type data() =
         inherit RegularNode()
+        [<Erase>]
         member this.value
             with set (value: string) = ()
 
+    [<Erase>]
     type time() =
         inherit RegularNode()
+        [<Erase>]
         member this.datetime
             with set (value: string) = ()
 
+    [<Erase>]
     type progress() =
         inherit RegularNode()
+        [<Erase>]
         member this.value
             with set (value: string) = ()
+        [<Erase>]
         member this.max
             with set (value: string) = ()
 
+    [<Erase>]
     type meter() =
         inherit RegularNode()
+        [<Erase>]
         member this.form
             with set (value: string) = ()
+        [<Erase>]
         member this.value
             with set (value: string) = ()
+        [<Erase>]
         member this.min
             with set (value: string) = ()
+        [<Erase>]
         member this.max
             with set (value: string) = ()
+        [<Erase>]
         member this.low
             with set (value: string) = ()
+        [<Erase>]
         member this.high
             with set (value: string) = ()
+        [<Erase>]
         member this.optimum
             with set (value: string) = ()
 
+    [<Erase>]
     type details() =
         inherit RegularNode()
+        [<Erase>]
         member this.open'
             with set (value: bool) = ()
 
+    [<Erase>]
     type summary() =
         inherit RegularNode()
 
+    [<Erase>]
     type dialog() =
         inherit RegularNode()
+        [<Erase>]
         member this.open'
             with set (value: bool) = ()
 
+    [<Erase>]
     type menu() =
         inherit RegularNode()
 
+    [<Erase>]
     type datalist() =
         inherit RegularNode()
 
+    [<Erase>]
     type fieldset() =
         inherit RegularNode()
+        [<Erase>]
         member this.disabled
             with set (value: bool) = ()
 
+        [<Erase>]
         member this.form
             with set (value: string) = ()
+        [<Erase>]
         member this.name
             with set (value: string) = ()
 
+    [<Erase>]
     type legend() =
         inherit RegularNode()
+    [<Erase>]
     type table() =
         inherit RegularNode()
+    [<Erase>]
     type tbody() =
         inherit RegularNode()
+    [<Erase>]
     type thead() =
         inherit RegularNode()
+    [<Erase>]
     type tfoot() =
         inherit RegularNode()
+    [<Erase>]
     type tr() =
         inherit RegularNode()
+    [<Erase>]
     type th() =
         inherit RegularNode()
+        [<Erase>]
         member this.abbr
             with set (value: string) = ()
+        [<Erase>]
         member this.colspan
             with set (value: int) = ()
+        [<Erase>]
         member this.rowspan
             with set (value: int) = ()
+        [<Erase>]
         member this.headers
             with set (value: string) = ()
+        [<Erase>]
         member this.scope
             with set (value: string) = ()
+    [<Erase>]
     type td() =
         inherit RegularNode()
+        [<Erase>]
         member this.colspan
             with set (value: int) = ()
+        [<Erase>]
         member this.rowspan
             with set (value: int) = ()
+        [<Erase>]
         member this.headers
             with set (value: string) = ()
 
+    [<Erase>]
     type map() =
         inherit RegularNode()
+        [<Erase>]
         member this.name
             with set (value: string) = ()
+    [<Erase>]
     type area() =
         inherit VoidNode()
+        [<Erase>]
         member this.shape
             with set (value: string) = ()
+        [<Erase>]
         member this.coords
             with set (value: string) = ()
+        [<Erase>]
         member this.href
             with set (value: string) = ()
+        [<Erase>]
         member this.alt
             with set (value: string) = ()
+        [<Erase>]
         member this.download
             with set (value: string) = ()
+        [<Erase>]
         member this.target
             with set (value: string) = ()
+        [<Erase>]
         member this.rel
             with set (value: string) = ()
+        [<Erase>]
         member this.referrerpolicy
             with set (value: string) = ()
+        [<Erase>]
         member this.ping
             with set (value: string) = ()
 
+    [<Erase>]
     type aside() =
         inherit RegularNode()
+    [<Erase>]
     type bdi() =
         inherit RegularNode()
+    [<Erase>]
     type bdo() =
         inherit RegularNode()
+    [<Erase>]
     type col() =
         inherit VoidNode()
+        [<Erase>]
         member this.span
             with set (value: int) = ()
+    [<Erase>]
     type colgroup() =
         inherit RegularNode()
+        [<Erase>]
         member this.span
             with set (value: int) = ()
+    [<Erase>]
     type dd() =
         inherit RegularNode()
+    [<Erase>]
     type dl() =
         inherit RegularNode()
+    [<Erase>]
     type dt() =
         inherit RegularNode()
+    [<Erase>]
     type embed() =
         inherit VoidNode()
+        [<Erase>]
         member this.src
             with set (value: string) = ()
+        [<Erase>]
         member this.type'
             with set (value: string) = ()
+        [<Erase>]
         member this.width
             with set (value: int) = ()
+        [<Erase>]
         member this.height
             with set (value: int) = ()
+    [<Erase>]
     type figcaption() =
         inherit RegularNode()
+    [<Erase>]
     type figure() =
         inherit RegularNode()
+    [<Erase>]
     type kbd() =
         inherit RegularNode()
+    [<Erase>]
     type mark() =
         inherit RegularNode()
+    [<Erase>]
     type picture() =
         inherit RegularNode()
+    [<Erase>]
     type samp() =
         inherit RegularNode()
+    [<Erase>]
     type var() =
         inherit RegularNode()
+    [<Erase>]
     type wbr() =
         inherit RegularNode()

--- a/tests/Oxpecker.Solid.Tests/.config/dotnet-tools.json
+++ b/tests/Oxpecker.Solid.Tests/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "4.22.0",
+      "version": "4.23.0",
       "commands": [
         "fable"
       ],

--- a/tests/Oxpecker.Solid.Tests/Cases/EventHandler/EventHandler.expected
+++ b/tests/Oxpecker.Solid.Tests/Cases/EventHandler/EventHandler.expected
@@ -1,4 +1,4 @@
-import { some } from "./fable_modules/fable-library-js.4.22.0/Option.js";
+import { some } from "./fable_modules/fable-library-js.4.23.0/Option.js";
 
 export function clicked2(evt) {
     console.log(some(evt.type));

--- a/tests/Oxpecker.Solid.Tests/Cases/HelloWorld/HelloWorld.expected
+++ b/tests/Oxpecker.Solid.Tests/Cases/HelloWorld/HelloWorld.expected
@@ -1,4 +1,4 @@
-import { some } from "./fable_modules/fable-library-js.4.22.0/Option.js";
+import { some } from "./fable_modules/fable-library-js.4.23.0/Option.js";
 
 export function Test() {
     console.log(some("Hello, World!"));

--- a/tests/Oxpecker.Solid.Tests/Cases/Parameters/Parameters.expected
+++ b/tests/Oxpecker.Solid.Tests/Cases/Parameters/Parameters.expected
@@ -1,4 +1,4 @@
-import { int32ToString } from "./fable_modules/fable-library-js.4.22.0/Util.js";
+import { int32ToString } from "./fable_modules/fable-library-js.4.23.0/Util.js";
 
 export function Test(id) {
     return <div id={int32ToString(id)}

--- a/tests/Oxpecker.Solid.Tests/GeneralTests.fs
+++ b/tests/Oxpecker.Solid.Tests/GeneralTests.fs
@@ -13,7 +13,7 @@ let ``Fable version`` () =
     }
     |> Command.execute
     |> Output.toText
-    |> shouldEqual "4.22.0"
+    |> shouldEqual "4.23.0"
 
 [<Fact>]
 let ``Hello world`` () =

--- a/tests/Oxpecker.Solid.Tests/SolidCases/Children/Children.expected
+++ b/tests/Oxpecker.Solid.Tests/SolidCases/Children/Children.expected
@@ -1,6 +1,6 @@
-import { int32ToString } from "./fable_modules/fable-library-js.4.22.0/Util.js";
-import { toArray } from "./fable_modules/fable-library-js.4.22.0/Seq.js";
-import { rangeDouble } from "./fable_modules/fable-library-js.4.22.0/Range.js";
+import { int32ToString } from "./fable_modules/fable-library-js.4.23.0/Util.js";
+import { toArray } from "./fable_modules/fable-library-js.4.23.0/Seq.js";
+import { rangeDouble } from "./fable_modules/fable-library-js.4.23.0/Range.js";
 
 export function Component(hello, children) {
     return <h1>

--- a/tests/Oxpecker.Solid.Tests/SolidCases/Components/Components.expected
+++ b/tests/Oxpecker.Solid.Tests/SolidCases/Components/Components.expected
@@ -1,4 +1,4 @@
-import { some } from "./fable_modules/fable-library-js.4.22.0/Option.js";
+import { some } from "./fable_modules/fable-library-js.4.23.0/Option.js";
 import { createSignal } from "solid-js";
 
 export function Component(getText) {

--- a/tests/Oxpecker.Solid.Tests/SolidCases/Iterators/Iterators.expected
+++ b/tests/Oxpecker.Solid.Tests/SolidCases/Iterators/Iterators.expected
@@ -1,4 +1,4 @@
-import { int32ToString } from "./fable_modules/fable-library-js.4.22.0/Util.js";
+import { int32ToString } from "./fable_modules/fable-library-js.4.23.0/Util.js";
 
 export function Test() {
     return <div>

--- a/tests/Oxpecker.Solid.Tests/SolidCases/Refs/Refs.expected
+++ b/tests/Oxpecker.Solid.Tests/SolidCases/Refs/Refs.expected
@@ -1,6 +1,6 @@
-import { defaultOf } from "./fable_modules/fable-library-js.4.22.0/Util.js";
+import { defaultOf } from "./fable_modules/fable-library-js.4.23.0/Util.js";
 import { onMount } from "solid-js";
-import { some } from "./fable_modules/fable-library-js.4.22.0/Option.js";
+import { some } from "./fable_modules/fable-library-js.4.23.0/Option.js";
 
 export function Test() {
     const htmlCanvas = defaultOf();


### PR DESCRIPTION
Hello,

## Why

Looking at Oxpecker.Solid output I was impressed with how little addition it does compare to manual written code in JSX. And kept, thinking it would be nice to make it even smaller.

Because Oxpecker.Solid is more or less only a binding to expose HTML/JSX API for `Oxpecker.Solid.FablePlugin`, we can improve the code generation.

By using `[<Erase>]` attributes, we can tell Fable that we don't want it to generate the code for current item.

## Impact

Thanks to that for example, when running `npm start` in the TodoList example. Some of the files don't even have a JSX file generated with them at all.

- `Oxpecker.Solid/Aria.fs`
- `Oxpecker.Solid/Builder.fs`
- `Oxpecker.Solid/Tags.fs`
- `Oxpecker.Solid/IdeTweaks.fs` (it actually has 2 functions generated but with future version of Fable it should not be the case, I missed something when adding `[<Erase>]` attribute support on member in Fable 4.23.0)

The others files from `Oxpecker.Solid/.fs` also got their output minimised but I could not erase all the code, sometimes it was required at runtime.

## Notes

- In order, for the optimisation to work user need to use Fable 4.23.0 at least, but the code is compatible with older Fable version. The `[<Erase>]` on member will just be ignored

	In theory, the previous code should be removed by bundler because they should have seen it has dead code, but sometimes they are not able to do it. So if we don't generate the code, we know for sure it will not have an impact on the final bundle size
	
- For code like `Extensions.Run`, I was not able to know how they were called, so I decided to use `[<Erase>]` on them too. In theory, `inline` would have the same effect but perhaps it would probably have broken this detection:

https://github.com/Lanayx/Oxpecker/blob/108dc2e445d448bb0adfd62a10a00243a454fae9/src/Oxpecker.Solid.FablePlugin/Library.fs#L47-L54
- I decided to use `[<Erase>]` instead of `inline` on setter for the same reason. When using `inline` I don't think we have enough information in the AST to know which property was set so the plugin can't generate the appropriate JSX.
- I decided to optimise out everything in `IdeTweaks` because this is not code exposed to the user and also it is here only for IDE improvements in Rider (I think).

My way to test if my modifications works, was to run the Todo app demo, and it seems to be working. Sowing that normal HTML element works and also things like the `For(each ...)` elements. 