### PR TITLE
fixing AlpineJs warning

### DIFF
--- a/examples/WeatherApp/templates/shared/layout.fs
+++ b/examples/WeatherApp/templates/shared/layout.fs
@@ -84,7 +84,7 @@ module layout =
                 link(rel="stylesheet", href="/app.css")
                 link(rel="icon", type'="image/png", href="/favicon.png")
                 script(src="https://unpkg.com/htmx.org@1.9.10", crossorigin="anonymous")
-                script(src="https://cdn.jsdelivr.net/npm/alpinejs@3.13.5/dist/cdn.min.js", crossorigin="anonymous")
+                script(defer=true, src="https://cdn.jsdelivr.net/npm/alpinejs@3.13.5/dist/cdn.min.js", crossorigin="anonymous")
             }
             body(hxBoost=true) {
                 mainLayout ctx content


### PR DESCRIPTION
##Problem

The web browser console shows the following warning

```
Alpine Warning: Unable to initialize. Trying to load Alpine before `<body>` is available. Did you forget to add `defer` in Alpine's `<script>` tag?
```

## Solution

Add defer tag when loading AlpineJs