### PR TITLE
Make Solid tests EOL-agnostic

### DIFF
--- a/tests/Oxpecker.Solid.Tests/Common.fs
+++ b/tests/Oxpecker.Solid.Tests/Common.fs
@@ -15,8 +15,8 @@ let private runCase folderName caseName =
     |> Output.toExitCode
     |> shouldEqual 0
 
-    let result = File.ReadAllText($"{dir}/{caseName}.jsx")
-    let expected = File.ReadAllText($"{dir}/{caseName}.expected")
+    let result = File.ReadAllLines($"{dir}/{caseName}.jsx")
+    let expected = File.ReadAllLines($"{dir}/{caseName}.expected")
     result |> shouldEqual expected
 
 let runGeneralCase caseName =


### PR DESCRIPTION
On Windows, jsx files are created with CRLF whereas the expected files are LF.  Using ReadAllLines instead of ReadAllText is a simple solution.