### PR TITLE
[Oxpecker.Solid][Docs] Add documentation to compiler plugin

### DIFF
--- a/src/Oxpecker.Solid.FablePlugin/Library.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Library.fs
@@ -39,25 +39,23 @@ module internal rec AST =
     let (|CallTag|_|) condition =
         function
         | Call(Import(importInfo, LambdaType(_, DeclaredType(typ, _)), _), callInfo, _, range) when condition importInfo ->
-            match callInfo.Args with
-            | LibraryTagImport(imp, _) :: _
-            | Let(_, LibraryTagImport(imp, _), _) :: _ -> LibraryImport imp
-            | _ ->
-                match
+            let tagImport =
+                match callInfo.Args with
+                | LibraryTagImport(imp, _) :: _
+                | Let(_, LibraryTagImport(imp, _), _) :: _ -> LibraryImport imp
+                | _ ->
                     let tagName = typ.FullName.Split('.') |> Seq.last
-                    in tagName
-                with
-                | "Fragment" ->
-                    ""
-                | tagName when tagName.EndsWith("'") ->
-                    tagName.Substring(0, tagName.Length - 1)
-                | tagName when tagName.EndsWith("`1") ->
-                    tagName.Substring(0, tagName.Length - 2)
-                | tagName ->
-                    tagName
-                |> AutoImport
-            |> fun tagImport ->
-                Some (tagImport, callInfo, range)
+                    let finalTagName =
+                        if tagName = "Fragment" then
+                            ""
+                        elif tagName.EndsWith("'") then
+                            tagName.Substring(0, tagName.Length - 1)
+                        elif tagName.EndsWith("`1") then
+                            tagName.Substring(0, tagName.Length - 2)
+                        else
+                            tagName
+                    AutoImport finalTagName
+            Some(tagImport, callInfo, range)
         | _ -> None
     /// <summary>
     /// Pattern matches expressions to Tags calls without children


### PR DESCRIPTION
I added some documentation for myself while grokkin the plugin and thought I'd share if you were interested.

There is one opinionated change I did to clarify for myself the flow of operations in one pattern match, this is marked specifically by the [relevant commit](1a1df7283ea5d8eb5c8c6914e51553142f87d94d) 