### PR TITLE
[Oxpecker.ViewEngine][Enhancement] Render Empty Element Tags according to XML spec

### DIFF
--- a/src/Oxpecker.Solid.FablePlugin/Library.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Library.fs
@@ -39,25 +39,23 @@ module internal rec AST =
     let (|CallTag|_|) condition =
         function
         | Call(Import(importInfo, LambdaType(_, DeclaredType(typ, _)), _), callInfo, _, range) when condition importInfo ->
-            match callInfo.Args with
-            | LibraryTagImport(imp, _) :: _
-            | Let(_, LibraryTagImport(imp, _), _) :: _ -> LibraryImport imp
-            | _ ->
-                match
+            let tagImport =
+                match callInfo.Args with
+                | LibraryTagImport(imp, _) :: _
+                | Let(_, LibraryTagImport(imp, _), _) :: _ -> LibraryImport imp
+                | _ ->
                     let tagName = typ.FullName.Split('.') |> Seq.last
-                    in tagName
-                with
-                | "Fragment" ->
-                    ""
-                | tagName when tagName.EndsWith("'") ->
-                    tagName.Substring(0, tagName.Length - 1)
-                | tagName when tagName.EndsWith("`1") ->
-                    tagName.Substring(0, tagName.Length - 2)
-                | tagName ->
-                    tagName
-                |> AutoImport
-            |> fun tagImport ->
-                Some (tagImport, callInfo, range)
+                    let finalTagName =
+                        if tagName = "Fragment" then
+                            ""
+                        elif tagName.EndsWith("'") then
+                            tagName.Substring(0, tagName.Length - 1)
+                        elif tagName.EndsWith("`1") then
+                            tagName.Substring(0, tagName.Length - 2)
+                        else
+                            tagName
+                    AutoImport finalTagName
+            Some(tagImport, callInfo, range)
         | _ -> None
     /// <summary>
     /// Pattern matches expressions to Tags calls without children

--- a/src/Oxpecker.ViewEngine/Tools.fs
+++ b/src/Oxpecker.ViewEngine/Tools.fs
@@ -40,6 +40,8 @@ type internal CustomQueue<'T> =
                 next <- next.Next
         }
 
+    member this.IsEmpty() = isNull this.Head
+
 module CustomWebUtility =
 
     [<Literal>]

--- a/tests/Oxpecker.ViewEngine.Tests/Render.Tests.fs
+++ b/tests/Oxpecker.ViewEngine.Tests/Render.Tests.fs
@@ -24,7 +24,7 @@ let ``Basic test`` () =
     result
     |> Render.toString
     |> shouldEqual
-        """<html><div id="1"></div><div id="2"><div id="3" class="test"></div><br><br><div id="4"></div></div></html>"""
+        """<html><div id="1"/><div id="2"><div id="3" class="test"/><br><br><div id="4"/></div></html>"""
 
 
 [<Fact>]
@@ -69,7 +69,7 @@ let ``Aria test`` () =
     result
     |> Render.toString
     |> shouldEqual
-        """<span role="checkbox" id="checkBoxInput" aria-checked="false" tabindex="0" aria-labelledby="chk15-label"></span>"""
+        """<span role="checkbox" id="checkBoxInput" aria-checked="false" tabindex="0" aria-labelledby="chk15-label"/>"""
 
 [<Fact>]
 let ``Only children test`` () =
@@ -114,7 +114,7 @@ let ``Basic chunked test`` () =
         stream.Seek(0L, SeekOrigin.Begin) |> ignore
         stream.ToArray()
         |> Encoding.UTF8.GetString
-        |> shouldEqual """<html><div id="1"></div></html>"""
+        |> shouldEqual """<html><div id="1"/></html>"""
     }
 
 [<Fact>]
@@ -128,5 +128,5 @@ let ``Render to text writer`` () =
         stream.Seek(0L, SeekOrigin.Begin) |> ignore
         stream.ToArray()
         |> Encoding.UTF8.GetString
-        |> shouldEqual $"""<!DOCTYPE html>{Environment.NewLine}<html><div id="1"></div></html>"""
+        |> shouldEqual $"""<!DOCTYPE html>{Environment.NewLine}<html><div id="1"/></html>"""
     }


### PR DESCRIPTION
This pull adds:
- Short member alias for checking if the CustomQueue is empty
- Refactors out attribute renderer from start tag renderer
- Adds empty element tag renderer

This matches the [xml spec](https://www.w3.org/TR/xml/#sec-starttags:~:text=Tags%20for%20Empty,br%3E%3C/br%3E%0A%3Cbr/%3E) and removes some unexpected behaviours when unsafely injecting property spreads due to the children prop being nullified by the empty start/end tags.