### PR TITLE
[Oxpecker.Solid] Enhancement to allow spreading objects within elements

### DIFF
--- a/src/Oxpecker.Solid.FablePlugin/Library.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Library.fs
@@ -205,6 +205,7 @@ module internal rec AST =
                 | "bool", EventHandler(eventName, handler) -> ("bool:" + eventName, handler) :: restResults
                 | "data", EventHandler(eventName, handler) -> ("data-" + eventName, handler) :: restResults
                 | "attr", EventHandler(eventName, handler) -> (eventName, handler) :: restResults
+                | "spread", { Args = [ _; identExpr ] } -> ("__SPREAD_PROPERTY__", identExpr) :: restResults
                 | "ref", { Args = [ _; identExpr ] } -> ("ref", identExpr) :: restResults
                 | "style'", { Args = [ _; identExpr ] } -> ("style", identExpr) :: restResults
                 | "classList", { Args = [ _; identExpr ] } -> ("classList", identExpr) :: restResults

--- a/src/Oxpecker.Solid/Tags.fs
+++ b/src/Oxpecker.Solid/Tags.fs
@@ -23,6 +23,11 @@ module Tags =
         [<Extension; Erase>]
         static member attr(this: #HtmlTag, name: string, value: string) = this
 
+        /// Applies JS Object Spread to the given value within the given element. Care must be taken to provide valid
+        /// objects. Mostly used to pass on properties in bindings/imports to nested children.
+        [<Extension; Erase>]
+        static member spread(this: #HtmlTag, value: 'T) = this
+
         /// Add event handler to the element through the corresponding attribute
         [<Extension; Erase>]
         static member on(this: #HtmlTag, eventName: string, eventHandler: Event -> unit) = this


### PR DESCRIPTION
Add spread functionality pending https://github.com/fable-compiler/Fable/pull/4038

Syntax:

```fs
[<SolidComponent>]
let Button (props: SomeObj) =
    let local,others = Solid.splitProps(props, [| "class" |]) // user imported solid splitProps
    button().spread(others) { "I spread 📦" }
```

output

```jsx
<button {...others}>I spread 📦 </button>
```