### PR TITLE
[WIP] Modulation of FablePlugin to facilitate tracing

### DIFF
--- a/src/Oxpecker.Solid.FablePlugin/Library.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Library.fs
@@ -219,8 +219,8 @@ module internal rec AST =
                         let tagName = typ.FullName.Split('.') |> Seq.last
                         match tagName with
                         | "Fragment" -> ""
-                        | _ when tagName.EndsWith("'") -> tagName[0..tagName.Length-1]
-                        | _ when tagName.EndsWith("`1") -> tagName[0..tagName.Length-2]
+                        | _ when tagName.EndsWith("'") -> tagName.Substring(0, tagName.Length - 1)
+                        | _ when tagName.EndsWith("`1") -> tagName.Substring(0, tagName.Length - 2)
                         | _ -> tagName
                         |> AutoImport
                 callInfo
@@ -362,7 +362,7 @@ module internal rec AST =
                             builder.trace("Setter > 0") |> ignore
                             let propertyName =
                                 match memberRefInfo.CompiledName.Substring(setterIndex + "set_".Length) with
-                                | name when name.EndsWith("'") -> name[0..name.Length - 1]
+                                | name when name.EndsWith("'") -> name.Substring(0, name.Length - 1)
                                 | name when name.StartsWith("aria") -> $"aria-{name.Substring(4).ToLower()}"
                                 | name -> name
                             let propertyValue = callInfo.Args.Head

--- a/src/Oxpecker.Solid.FablePlugin/Library.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Library.fs
@@ -8,460 +8,464 @@ open Fable.AST.Fable
 [<assembly: ScanForPlugins>]
 do () // Prompts fable to utilise this plugin
 
+type Tracer = Tracer of string seq with
+    static member create s = Tracer s
+    static member init = Tracer (seq {})
+    member inline this.Value = let (Tracer value) = this in value
+    #if DEBUG
+    member this.add s = Tracer (this.Value |> Seq.append s)
+    member this.add (t : Tracer) = Tracer (this.Value |> Seq.append t.Value)
+    #else
+    member this.add 't = this
+    #endif
+
 module internal rec AST =
     /// <summary>
-    /// AST Representation for a JSX Attribute/property. Tuple of name and value
+    /// Property definition of a <c>string * Fable.Expr</c> tuple
     /// </summary>
-    type PropInfo = string * Expr
+    type Property = string * Expr
+    module Property = let create s e  : Property = s, e
     /// <summary>
-    /// List of AST property name value pairs
+    /// List of Property definitions
     /// </summary>
-    type Props = PropInfo list
-
+    type PropertyList = Property list
+    /// <summary>A tags name or import origin expression</summary>
     type TagSource =
-        | AutoImport of tagName: string
-        | LibraryImport of imp: Expr
+        | AutoImport of name: string
+        | LibraryImport of importExpr: Expr
     /// <summary>
-    /// DU which distinguishes between a user call instantiating the tag with children, without children (props only),
-    /// or with both children AND properties.
+    /// The possible information groupings that are contained in an elements Builder
     /// </summary>
-    type TagInfo =
-        | WithChildren of tagName: TagSource * propsAndChildren: CallInfo * range: SourceLocation option
-        | NoChildren of tagName: TagSource * props: Expr list * range: SourceLocation option
-        | Combined of tagName: TagSource * props: Expr list * propsAndChildren: CallInfo * range: SourceLocation option
-
+    type TagBuilderInfo =
+        | Children of propsAndChildren: CallInfo
+        | Props of props: Expr list
+        | Combined  of props: Expr list * propsAndChildren: CallInfo
+        static member create c = Children c
+        static member create p = Props p
+        static member create (e: Expr list, c: CallInfo) = Combined (e,c)
     /// <summary>
-    /// Pattern matches expressions for Tags calls.
+    /// Collation of an elements build information
     /// </summary>
-    /// <param name="condition"><c>ImportInfo</c></param>
-    /// <remarks>Apostrophised tagnames are cleaned of the apostrophe during transpilation</remarks>
-    /// <returns><c>TagSource * CallInfo * SourceLocation option</c></returns>
-    let (|CallTag|_|) condition =
-        function
-        | Call(Import(importInfo, LambdaType(_, DeclaredType(typ, _)), _), callInfo, _, range) when condition importInfo ->
-            let tagImport =
-                match callInfo.Args with
-                | LibraryTagImport(imp, _) :: _
-                | Let(_, LibraryTagImport(imp, _), _) :: _ -> LibraryImport imp
+    type TagBuilder =
+        {
+            Tag: TagSource
+            Info: TagBuilderInfo
+            Range: SourceLocation option
+            Tracer: Tracer
+        }
+        static member create (tag, info, range) = { Tag=tag;Info=info;Range=range;Tracer=Tracer.init}
+        static member create (tag, info) = { Tag=tag;Info=info;Range=None;Tracer=Tracer.init}
+        static member tag tag builder = { builder with Tag = tag }
+        static member info info builder = { builder with Info = info }
+        static member range range (builder : TagBuilder) = { builder with Range = range }
+    /// <summary>
+    /// A special handled property/attribute pair, produced by Element Extensions such as attr, bool etc
+    /// </summary>
+    type EventHandler = { Name : string ; Handler : Fable.Expr }
+    module TagBuilder =
+        type info =
+            /// <summary>
+            /// Adds an expression to a builders information collection
+            /// </summary>
+            /// <param name="e"><c>Fable.Expr</c></param>
+            /// <param name="builder"><c>TagBuilder</c></param>
+            /// <returns>If the builder has a prop list, then it will append the expression to the list</returns>
+            static member add e builder =
+                match builder.Info with
+                | Props propertyList
+                | Combined (propertyList, _) -> // TODO -> should this keep subtype?
+                    { builder with Info = TagBuilderInfo.create (e :: propertyList) }
                 | _ ->
-                    let tagName = typ.FullName.Split('.') |> Seq.last
-                    let finalTagName =
-                        if tagName = "Fragment" then
-                            ""
-                        elif tagName.EndsWith("'") then
-                            tagName.Substring(0, tagName.Length - 1)
-                        elif tagName.EndsWith("`1") then
-                            tagName.Substring(0, tagName.Length - 2)
-                        else
-                            tagName
-                    AutoImport finalTagName
-            Some(tagImport, callInfo, range)
-        | _ -> None
-    /// <summary>
-    /// Pattern matches expressions to Tags calls without children
-    /// </summary>
-    /// <returns><c>TagInfo.NoChildren</c></returns>
-    let (|TagNoChildren|_|) (expr: Expr) =
-        let condition = _.Selector.EndsWith("_$ctor")
-        match expr with
-        | CallTag condition (tagName, _, range) -> Some(tagName, range)
-        | _ -> None
-    /// <summary>
-    /// Pattern matches expressions to Tag calls with children
-    /// </summary>
-    /// <returns><c>TagInfo.WithChildren</c></returns>
-    let (|TagWithChildren|_|) (expr: Expr) =
-        let condition =
-            fun importInfo ->
-                importInfo.Selector.StartsWith("HtmlContainerExtensions_Run")
-                || importInfo.Selector.StartsWith("BindingsModule_Extensions_Run")
-        match expr with
-        | CallTag condition tagCallInfo -> Some tagCallInfo
-        | _ -> None
-    /// <summary>
-    /// Pattern matches <c>let</c> bindings that start with <c>element</c>
-    /// </summary>
-    /// <returns><c>unit</c></returns>
-    let (|LetElement|_|) =
-        function
-        | Let({ Name = name }, _, _) when name.StartsWith("element") -> Some()
-        | _ -> None
-    /// <summary>
-    /// Pattern matches <c>let</c> bindings for Tags with children
-    /// </summary>
-    /// <returns><c>TagInfo.WithChildren</c></returns>
-    let (|LetTagWithChildren|_|) =
-        function
-        | Let(_, TagWithChildren(tagName, callInfo, range), _) -> TagInfo.WithChildren(tagName, callInfo, range) |> Some
-        | _ -> None
-    /// <summary>
-    /// Pattern matches <c>let</c> bindings for Tags without children (but with props)
-    /// </summary>
-    /// <returns><c>TagInfo.NoChildren</c></returns>
-    let (|LetTagNoChildrenWithProps|_|) =
-        function
-        | Let(_, TagNoChildren(tagName, range), Sequential exprs) -> TagInfo.NoChildren(tagName, exprs, range) |> Some
-        | _ -> None
-    /// <summary>
-    /// Pattern matches expressions (<c>let</c> or otherwise) for tags without children directly to Tag calls
-    /// </summary>
-    /// <returns><c>TagInfo.NoChildren</c></returns>
-    let (|CallTagNoChildrenWithHandler|_|) (expr: Expr) =
-        match expr with
-        | Call(Import(importInfo, _, _),
-               {
-                   Args = TagNoChildren(tagName, _) :: _
-               },
-               _,
-               range) when importInfo.Selector.StartsWith("HtmlElementExtensions_") -> // on, attr, data, ref
-            TagInfo.NoChildren(tagName, [ expr ], range) |> Some
-        | Call(Import(importInfo, _, _),
-               {
-                   Args = LetTagNoChildrenWithProps(NoChildren(tagName, props, _)) :: _
-               },
-               _,
-               range) when importInfo.Selector.StartsWith("HtmlElementExtensions_") -> // on, attr, data, ref
-            TagInfo.NoChildren(tagName, expr :: props, range) |> Some
-        | Call(Import(importInfo, _, _),
-               {
-                   Args = CallTagNoChildrenWithHandler(NoChildren(tagName, props, _)) :: _
-               },
-               _,
-               range) when importInfo.Selector.StartsWith("HtmlElementExtensions_") -> // on, attr, data, ref
-            TagInfo.NoChildren(tagName, expr :: props, range) |> Some
-        | _ -> None
-    /// <summary>
-    /// Pattern matches <c>let</c> bindings for tags without children or props
-    /// </summary>
-    /// <returns><c>TagInfo.NoChildren</c></returns>
-    let (|LetTagNoChildrenNoProps|_|) =
-        function
-        | Let(_, TagNoChildren(tagName, range), _) -> TagInfo.NoChildren(tagName, [], range) |> Some
-        | _ -> None
-    /// <summary>
-    /// Pattern matches expressions that are text in isolation (no siblings)
-    /// </summary>
-    /// <returns><c>Expr</c> of text</returns>
-    let (|TextNoSiblings|_|) =
-        function
-        | Lambda({ Name = cont }, TypeCast(textBody, Unit), None) when cont.StartsWith("cont") -> Some textBody
-        | _ -> None
-    /// <summary>
-    /// Matches expressions for tags that are imported from a namespace starting with <c>Oxpecker.Solid</c>
-    /// </summary>
-    /// <returns><c>Expr * SourceLocation</c></returns>
-    let (|LibraryTagImport|_|) (expr: Expr) =
-        match expr with
-        | Call(Import({ Kind = UserImport false }, Any, _) as imp, { Tags = [ "new" ] }, DeclaredType(typ, []), range) when
-            typ.FullName.StartsWith("Oxpecker.Solid")
-            ->
-            Some(imp, range)
-        | _ -> None
-    /// <summary>
-    /// Plugin type declaration for JSX Element
-    /// </summary>
-    let jsxElementType =
-        Type.DeclaredType(
-            ref = {
-                FullName = "Fable.Core.JSX.Element"
-                Path = EntityPath.CoreAssemblyName "Fable.Core"
-            },
-            genericArgs = []
-        )
-    /// <summary>
-    /// Plugin import declaration for JSX <c>create</c>
-    /// </summary>
-    let importJsxCreate =
-        Import(
-            info = {
-                Selector = "create"
-                Path = "@fable-org/fable-library-js/JSX.js"
-                Kind = ImportKind.UserImport false
-            },
-            typ = Type.Any,
-            range = None
-        )
-
-
-    let private (|EventHandler|_|) callInfo =
-        match callInfo with
-        | {
-              Args = [ _; Value(StringConstant eventName, _); handler ]
-          } -> Some(eventName, handler)
-        | _ -> None
-
-    let rec collectAttributes (exprs: Expr list) =
-        match exprs with
-        | [] -> []
-        | Sequential expressions :: rest -> collectAttributes rest @ collectAttributes expressions
-        | Call(Import(importInfo, _, _), callInfo, _, _) :: rest ->
-            let restResults = collectAttributes rest
-            match importInfo.Kind with
-            | ImportKind.MemberImport(MemberRef(entity, memberRefInfo)) when
-                entity.FullName.StartsWith("Oxpecker.Solid")
-                ->
-                match memberRefInfo.CompiledName, callInfo with
-                | "on", EventHandler(eventName, handler) -> ("on:" + eventName, handler) :: restResults
-                | "bool", EventHandler(eventName, handler) -> ("bool:" + eventName, handler) :: restResults
-                | "data", EventHandler(eventName, handler) -> ("data-" + eventName, handler) :: restResults
-                | "attr", EventHandler(eventName, handler) -> (eventName, handler) :: restResults
-                | "ref", { Args = [ _; identExpr ] } -> ("ref", identExpr) :: restResults
-                | "style'", { Args = [ _; identExpr ] } -> ("style", identExpr) :: restResults
-                | "classList", { Args = [ _; identExpr ] } -> ("classList", identExpr) :: restResults
-                | _ ->
-                    let setterIndex = memberRefInfo.CompiledName.IndexOf("set_")
-                    if setterIndex >= 0 then
-                        let propName =
-                            match memberRefInfo.CompiledName.Substring(setterIndex + "set_".Length) with
-                            | name when name.EndsWith("'") -> name.Substring(0, name.Length - 1) // like class' or type'
-                            | name when name.StartsWith("aria") -> $"aria-{name.Substring(4).ToLower()}"
-                            | name -> name
-                        let propValue = callInfo.Args.Head
-                        match propValue with
-                        | TypeCast(expr,
-                                   DeclaredType({
-                                                    FullName = "Oxpecker.Solid.Builder.HtmlElement"
-                                                },
-                                                _)) -> (propName, transform expr) :: restResults
-                        | Delegate(args, expr, name, tags) ->
-                            (propName, Delegate(args, transform expr, name, tags)) :: restResults
-                        | _ -> (propName, propValue) :: restResults
-                    else
-                        restResults
-            | _ -> restResults
-        | Set(IdentExpr({ Name = returnVal }), SetKind.FieldSet name, _, handler, _) :: rest when
-            returnVal.StartsWith("returnVal")
-            ->
-            let propName =
-                match name with
-                | name when name.EndsWith("'") -> name.Substring(0, name.Length - 1) // like class' or type'
-                | name -> name
-            (propName, handler) :: collectAttributes rest
-        | _ :: rest -> collectAttributes rest
-
-    let getAttributes currentList (expr: Expr) : Props =
-        match expr with
-        | Let({ Name = returnVal }, _, Sequential exprs) when returnVal.StartsWith("returnVal") ->
-            collectAttributes exprs @ currentList
-        | CallTagNoChildrenWithHandler(NoChildren(_, props, _)) -> collectAttributes props @ currentList
-        | _ -> currentList
-
-    let getChildren currentList (expr: Expr) : Expr list =
-        match expr with
-        | LetTagWithChildren tagInfo ->
-            let newExpr = transformTagInfo tagInfo
-            newExpr :: currentList
-        | LetElement & Let(_, LetTagNoChildrenWithProps tagInfo, _) ->
-            let newExpr = transformTagInfo tagInfo
-            newExpr :: currentList
-        | LetElement & LetTagNoChildrenNoProps tagInfo ->
-            let newExpr = transformTagInfo tagInfo
-            newExpr :: currentList
-        | LetElement & Let(_, CallTagNoChildrenWithHandler tagInfo, _) ->
-            let newExpr = transformTagInfo tagInfo
-            newExpr :: currentList
-        | LetElement & Let(_, next, _) ->
-            let newExpr = transform next
-            newExpr :: currentList
-        // Lambda with two arguments returning element
-        | Lambda({ Name = cont }, TypeCast(Lambda(item, Lambda(index, next, _), _), _), _) when cont.StartsWith("cont") ->
-            Delegate([ item; index ], transform next, None, []) :: currentList
-        | TextNoSiblings body -> body :: currentList
-        // text with solid signals inside
-        | Let({ Name = text }, body, TextNoSiblings _) when text.StartsWith("text") -> body :: currentList
-        // text then tag
-        | Let({ Name = second }, next, Lambda({ Name = builder }, Sequential(TypeCast(textBody, Unit) :: _), _)) when
-            second.StartsWith("second") && builder.StartsWith("builder")
-            ->
-            getChildren (textBody :: currentList) next
-        // parameter then another parameter
-        | CurriedApply(Lambda({ Name = cont }, TypeCast(lastParameter, Unit), Some second), _, _, _) when
-            cont.StartsWith("cont") && second.StartsWith("second")
-            ->
-            lastParameter :: currentList
-        | CurriedApply(Lambda({ Name = builder }, Sequential [ TypeCast(middleParameter, Unit); next ], _), _, _, _)
-        | Lambda({ Name = builder }, Sequential [ TypeCast(middleParameter, Unit); next ], _) when
-            builder.StartsWith("builder")
-            ->
-            getChildren (middleParameter :: currentList) next
-        // tag then text
-        | Let({ Name = first }, next1, Lambda({ Name = builder }, Sequential [ CurriedApply _; next2 ], _)) when
-            first.StartsWith("first") && builder.StartsWith("builder")
-            ->
-            let next2Children = getChildren [] next2
-            let next1Children = getChildren [] next1
-            next2Children @ next1Children @ currentList
-        | Let({ Name = first }, Let(_, expr, _), Let({ Name = second }, next, _))
-        | Let({ Name = first }, expr, Let({ Name = second }, next, _)) when
-            first.StartsWith("first") && second.StartsWith("second")
-            ->
-            match expr with
-            | LetTagNoChildrenWithProps tagInfo ->
-                let newExpr = transformTagInfo tagInfo
-                getChildren (newExpr :: currentList) next
-            | TagNoChildren(tagName, range) ->
-                let newExpr = transformTagInfo(TagInfo.NoChildren(tagName, [], range))
-                getChildren (newExpr :: currentList) next
-            | TagWithChildren callInfo ->
-                let newExpr = transformTagInfo(TagInfo.WithChildren callInfo)
-                getChildren (newExpr :: currentList) next
-            | expr ->
-                let newExpr = transform expr
-                getChildren (newExpr :: currentList) next
-        | IfThenElse(guardExpr, thenExpr, elseExpr, range) ->
-            IfThenElse(guardExpr, transform thenExpr, transform elseExpr, range)
-            :: currentList
-        | DecisionTree(decisionTree, targets) ->
-            DecisionTree(decisionTree, targets |> List.map(fun (target, expr) -> target, transform expr))
-            :: currentList
-        // router cases
-        | Call(Get(IdentExpr _, FieldGet _, Any, _), { Args = args }, _, _) ->
-            match args with
-            | [ Call(Import({ Selector = "uncurry2" }, Any, None), { Args = [ Lambda(_, body, _) ] }, _, _) ] ->
-                getChildren currentList body
-            | [ LibraryTagImport(imp, _) ] ->
-                let newExpr = transformTagInfo(TagInfo.NoChildren(LibraryImport imp, [], None))
-                newExpr :: currentList
-            | [ Let(_, LibraryTagImport(imp, _), Sequential exprs) ] ->
-                let newExpr = transformTagInfo(TagInfo.NoChildren(LibraryImport imp, exprs, None))
-                newExpr :: currentList
-            | [ Let(_, Let(_, LibraryTagImport(imp, _), Sequential exprs), TagWithChildren(_, callInfo, _)) ] ->
-                let newExpr =
-                    transformTagInfo(TagInfo.Combined(LibraryImport imp, exprs, callInfo, None))
-                newExpr :: currentList
-            | [ next1; next2 ] ->
-                let next2Children = getChildren [] next2
-                let next1Children = getChildren [] next1
-                next2Children @ next1Children @ currentList
-            | [ expr ] -> expr :: currentList
-            | _ -> currentList
-        | Let({
-                  Name = name
-                  Range = range
-                  Type = DeclaredType({ FullName = fullName }, [])
-              },
-              _,
-              _) when
-            ((name.StartsWith("returnVal") && fullName.StartsWith("Oxpecker.Solid"))
-             || (name.StartsWith("element") && fullName.StartsWith("Oxpecker.Solid")))
-            |> not
-            ->
-            match range with
-            | Some range -> failwith $"`let` binding inside HTML CE can't be converted to JSX:line {range.start.line}"
-            | None -> failwith $"`let` binding inside HTML CE can't be converted to JSX"
-        | _ -> currentList
-
-    let listItemType =
-        Type.Tuple(genericArgs = [ Type.String; Type.Any ], isStruct = false)
-    let emptyList =
-        Value(kind = NewList(headAndTail = None, typ = listItemType), range = None)
-
-    let convertExprListToExpr (exprs: Expr list) =
-        (emptyList, exprs)
-        ||> List.fold(fun acc prop ->
-            Value(kind = NewList(headAndTail = Some(prop, acc), typ = listItemType), range = None))
-
-    let wrapChildrenExpression childrenExpression =
-        Value(
-            kind =
-                NewTuple(
-                    values = [
-                        // property name
-                        Value(kind = StringConstant "children", range = None)
-                        // property value
-                        TypeCast(childrenExpression, Type.Any)
-                    ],
-                    isStruct = false
-                ),
-            range = None
-        )
-
-    let transformTagInfo (tagInfo: TagInfo) : Expr =
-        let tagName, props, children, range =
-            match tagInfo with
-            | WithChildren(tagName, callInfo, range) ->
-                let props = callInfo.Args |> List.fold getAttributes []
-                let childrenList = callInfo.Args |> List.fold getChildren []
-                tagName, props, childrenList, range
-            | NoChildren(tagName, propList, range) ->
-                let props = collectAttributes propList
-                let childrenList = []
-                tagName, props, childrenList, range
-            | Combined(tagName, propList, callInfo, range) ->
-                let props = collectAttributes propList
-                let childrenList = callInfo.Args |> List.fold getChildren []
-                tagName, props, childrenList, range
-
-        let propsXs =
-            props
-            |> List.map(fun (name, expr) ->
-                Value(
-                    kind =
-                        NewTuple(
+                    failwith "Impossible"
+            /// <summary>
+            /// Adds an expression list to a builders information collection
+            /// </summary>
+            /// <param name="es"><c>Fable.Expr list</c></param>
+            /// <param name="builder"><c>TagBuilder</c></param>
+            /// <returns>Adds the expression list to the already existing expression list, or changes the type
+            /// of information collection to one that takes expression list (property type)</returns>
+            static member adds es builder =
+                match builder.Info with
+                | Children propsAndChildren -> { builder with Info = TagBuilderInfo.create (es, propsAndChildren) }
+                | Props props -> { builder with Info = TagBuilderInfo.create (es @ props) }
+                | Combined(props, propsAndChildren) -> { builder with Info = TagBuilderInfo.create (es @ props, propsAndChildren) }
+        /// <summary>
+        /// Collates and builds the collected tag properties and children
+        /// </summary>
+        /// <param name="builder"><c>TagBuilder</c></param>
+        /// <returns>Flattened expression of the built Tag</returns>
+        let transform builder =
+            let properties, children =
+                match builder.Info with
+                | Children propsAndChildren ->
+                    (propsAndChildren.Args |> List.fold Attributes.get [],
+                     propsAndChildren.Args |> List.fold Children.get [])
+                | Props props ->
+                    (Attributes.collect props,
+                     [])
+                | Combined(props, propsAndChildren) ->
+                    (Attributes.collect props,
+                     propsAndChildren.Args |> List.fold Children.get [])
+            let transformedProperties =
+                properties |> List.map (fun (name, expr) ->
+                    Value(
+                        kind = NewTuple(
                             values = [
-                                // property name
                                 Value(kind = StringConstant name, range = None)
-                                // property value
                                 TypeCast(expr, Type.Any)
                             ],
                             isStruct = false
                         ),
-                    range = None
-                ))
-        let childrenExpression = convertExprListToExpr children
+                        range = None
+                    ))
+            let childrenPropertyCollection =
+                (children |> Helpers.convertListToExpr |> Children.wrap ) :: transformedProperties
+                |> Helpers.convertListToExpr
+            let tag =
+                match builder.Tag with
+                | AutoImport tagName -> Value(StringConstant tagName, None)
+                | LibraryImport import -> import
 
-        let finalList = (wrapChildrenExpression childrenExpression) :: propsXs
-        let propsExpr = convertExprListToExpr finalList
-        let tag =
-            match tagName with
-            | AutoImport tagName -> Value(StringConstant tagName, None)
-            | LibraryImport imp -> imp
+            Call(
+                callee = Baked.importJsxCreate,
+                info = {
+                    ThisArg = None
+                    Args = [ tag; childrenPropertyCollection ]
+                    SignatureArgTypes = []
+                    GenericArgs = []
+                    MemberRef = None
+                    Tags = [ "jsx" ]
+                },
+                typ = Baked.jsxElementType,
+                range = builder.Range
+                )
 
-        Call(
-            callee = importJsxCreate,
-            info = {
-                ThisArg = None
-                Args = [ tag; propsExpr ]
-                SignatureArgTypes = []
-                GenericArgs = []
-                MemberRef = None
-                Tags = [ "jsx" ]
-            },
-            typ = jsxElementType,
-            range = range
-        )
+    // Pattern matchers //
+    (*
+    The pattern matchers collate under the root AST type.
+    ie - Let roots will have their active patterns collected under the `Let` module
+    eg - Let.WithChildren
+    *)
 
-    let transform (expr: Expr) =
+    [<RequireQualifiedAccess>]
+    module Ident =
+        let (|Equals|_|) (value : string) : Ident -> unit option =
+            function
+            | { Name = name } when name = value -> Some()
+            | _ -> None
+        let (|StartsWith|_|) (value : string) : Ident -> unit option =
+            function
+            | { Name = name } when name.StartsWith value -> Some()
+            | _ -> None
+    [<RequireQualifiedAccess>]
+    module Call =
+        let (|TagImport|_|) expr =
+            match expr with
+            | Call(Import({ Kind = UserImport false }, Any, _) as import, { Tags = [ "new" ] }, DeclaredType(typ, []), range)
+                when typ.FullName.StartsWith "Oxpecker.Solid" ->
+                Some(import, range)
+            | _ -> None
+        let (|Tag|_|) condition = function
+            | Call(Import(importInfo, LambdaType(_, DeclaredType(typ, _)), _), callInfo, _, range) when condition importInfo ->
+                let getTagSource = function
+                    | Call.TagImport(imp, _) :: _
+                    | Let(_, Call.TagImport(imp, _), _) :: _ -> LibraryImport imp
+                    | _ ->
+                        let tagName = typ.FullName.Split('.') |> Seq.last
+                        match tagName with
+                        | "Fragment" -> ""
+                        | _ when tagName.EndsWith("'") -> tagName[0..tagName.Length-1]
+                        | _ when tagName.EndsWith("`1") -> tagName[0..tagName.Length-2]
+                        | _ -> tagName
+                        |> AutoImport
+                callInfo
+                |> _.Args
+                |> getTagSource
+                |> fun tagSource ->
+                    TagBuilder.create (tagSource, TagBuilderInfo.create callInfo, range)
+                    |> Some
+            | _ -> None
+        let (|ImportCallRangeInfo|_|) = function
+            | Call(Import(importInfo, _, _), callInfo, _, range) -> Some (importInfo, callInfo, range)
+            | _ -> None
+    [<RequireQualifiedAccess>]
+    module Tag =
+        let (|NoChildren|_|) expr =
+            let condition = _.Selector.EndsWith("_$ctor")
+            match expr with
+            | Call.Tag condition tagBuilder -> Some tagBuilder
+            | _ -> None
+        let (|WithChildren|_|) expr =
+            let condition =
+                fun importInfo ->
+                    importInfo.Selector.StartsWith("HtmlContainerExtensions_Run")
+                    || importInfo.Selector.StartsWith("BindingsModule_Extensions_Run")
+            match expr with
+            | Call.Tag condition tagBuilder -> Some tagBuilder
+            | _ -> None
+        let (|NoChildrenWithHandler|_|) expr =
+            match expr with
+            | Call.ImportCallRangeInfo (importInfo, { Args = args :: _ }, range)
+                when importInfo.Selector.StartsWith("HtmlElementExtensions_") ->
+                match args with
+                | Tag.NoChildren builder ->
+                    builder
+                    |> TagBuilder.info (TagBuilderInfo.create [ expr ])
+                    |> TagBuilder.range range
+                    |> Some
+                | Let.NoChildrenWithProps builder
+                | Tag.NoChildrenWithHandler builder ->
+                    builder
+                    |> TagBuilder.info.add expr
+                    |> TagBuilder.range range
+                    |> Some
+                | _ -> None
+            | _ -> None
+    [<RequireQualifiedAccess>]
+    module Let =
+        let (|Element|_|) = function
+            | Let(Ident.StartsWith "element", _, _) -> Some()
+            | _ -> None
+        let (|WithChildren|_|) = function
+            | Let(_, Tag.WithChildren builder, _) -> builder |> Some
+            | _ -> None
+        let (|NoChildrenWithProps|_|) = function
+            | Let(_, Tag.NoChildren builder, Sequential exprs) -> Some { builder with Info = TagBuilderInfo.create exprs }
+            | _ -> None
+        let (|NoChildrenNoProps|_|) =
+            function
+            | Let(_, Tag.NoChildren builder, _) ->
+                builder
+                |> TagBuilder.info (TagBuilderInfo.create [])
+                |> Some
+            | _ -> None
+    [<RequireQualifiedAccess>]
+    module Lambda =
+        let (|TextNoSiblings|_|) = function
+            | Lambda(Ident.StartsWith "cont", TypeCast(textBody, Unit), None) ->
+                Some textBody
+            | _ -> None
+    [<RequireQualifiedAccess>]
+    module CallInfo =
+        let (|EventHandler|_|) callInfo =
+            match callInfo with
+            | { Args = [ _; Value(StringConstant eventName, _); handler ] } ->
+                Some({ Name = eventName ; Handler = handler })
+            | _ -> None
+    [<RequireQualifiedAccess>]
+    module Baked =
+        let jsxElementType =
+            Type.DeclaredType(
+                ref = {
+                    FullName = "Fable.Core.JSX.Element"
+                    Path = EntityPath.CoreAssemblyName "Fable.Core"
+                },
+                genericArgs = []
+            )
+        let importJsxCreate =
+            Import(
+                info = {
+                    Selector = "create"
+                    Path = "@fable-org/fable-library-js/JSX.js"
+                    Kind = ImportKind.UserImport false
+                },
+                typ = Type.Any,
+                range = None
+            )
+        let listItemType =
+            Type.Tuple(genericArgs = [ Type.String; Type.Any ], isStruct = false)
+        let emptyList =
+            Value(kind = NewList(headAndTail = None, typ = listItemType), range = None)
+
+    [<RequireQualifiedAccess>]
+    module Attributes =
+        /// <summary>
+        /// Matches predefined Element Extension attributes/properties when given
+        /// a <c>string * CallInfo</c> tuple
+        /// </summary>
+        let (|ElementExtension|_|) = function
+            | "on", CallInfo.EventHandler eventHandler -> Property.create ("on:" + eventHandler.Name) eventHandler.Handler |> Some
+            | "bool", CallInfo.EventHandler eventHandler -> Property.create ("bool:" + eventHandler.Name) eventHandler.Handler |> Some
+            | "data", CallInfo.EventHandler eventHandler -> Property.create ("data-" + eventHandler.Name) eventHandler.Handler |> Some
+            | "attr", CallInfo.EventHandler eventHandler -> Property.create eventHandler.Name eventHandler.Handler |> Some
+            | "ref", { Args = [ _; identExpr ] } -> Property.create "ref" identExpr |> Some
+            | "style", { Args = [ _; identExpr ] } -> Property.create "style" identExpr |> Some
+            | "classList", { Args = [ _; identExpr ] } -> Property.create "classList" identExpr |> Some
+            | _ -> None
+        let rec collect exprs =
+            match exprs with
+            | [] -> []
+            | Sequential expressions :: rest -> Attributes.collect rest @ Attributes.collect expressions
+            | Call.ImportCallRangeInfo (importInfo, callInfo, _) :: rest ->
+                let restResults = Attributes.collect rest
+                match importInfo.Kind with
+                | ImportKind.MemberImport(MemberRef(entity, memberRefInfo))
+                    when entity.FullName.StartsWith("Oxpecker.Solid") ->
+                    match memberRefInfo.CompiledName, callInfo with
+                    | Attributes.ElementExtension extensionProperty -> extensionProperty :: restResults
+                    | _ ->
+                        let setterIndex = memberRefInfo.CompiledName.IndexOf("set_")
+                        if setterIndex >= 0 then
+                            let propertyName =
+                                match memberRefInfo.CompiledName.Substring(setterIndex + "set_".Length) with
+                                | name when name.EndsWith("'") -> name[0..name.Length - 1]
+                                | name when name.StartsWith("aria") -> $"aria-{name.Substring(4).ToLower()}"
+                                | name -> name
+                            let propertyValue = callInfo.Args.Head
+                            match propertyValue with
+                            | TypeCast(expr, DeclaredType({ FullName = "Oxpecker.Solid.Builder.HtmlElement" }, _)) ->
+                                transform expr
+                                |> Property.create propertyName
+                            | Delegate(args, expr, name, tags) ->
+                                Delegate(args, transform expr, name, tags)
+                                |> Property.create propertyName
+                            | _ -> Property.create propertyName propertyValue
+                            |> fun property -> property :: restResults
+                        else
+                            restResults
+                | _ -> restResults
+            | Set(IdentExpr(Ident.StartsWith "returnVal"), SetKind.FieldSet name, _, handler, _) :: rest ->
+                let propertyName = name |> function
+                    | _ when name.EndsWith("'") -> name.Substring(0, name.Length - 1)
+                    | _ -> name
+                Property.create propertyName handler
+                |> fun property -> property :: Attributes.collect rest
+            | _ :: rest -> Attributes.collect rest
+        let get current expr : PropertyList =
+            match expr with
+            | Let(Ident.StartsWith "returnVal", _, Sequential exprs) ->
+                Attributes.collect exprs @ current
+            | Tag.NoChildrenWithHandler { Info = TagBuilderInfo.Props props } ->
+                Attributes.collect props @ current
+            | _ -> current
+    module Children =
+        let get current expr : Expr list =
+            match expr with
+            | Let.WithChildren builder
+            | Let.Element & Let(_, Let.NoChildrenWithProps builder, _)
+            | Let.Element & Let.NoChildrenNoProps builder
+            | Let.Element & Let(_, Tag.NoChildrenWithHandler builder, _) ->
+                TagBuilder.transform builder :: current
+            | Let.Element & Let(_, next, _) ->
+                transform next :: current
+            | Lambda(Ident.StartsWith "cont", TypeCast(Lambda(item, Lambda(index, next, _), _), _), _) ->
+                Delegate([ item; index ], transform next, None, []) :: current
+            | Lambda.TextNoSiblings body -> body :: current
+            | Let(Ident.StartsWith "text", body, Lambda.TextNoSiblings _) ->
+                body :: current
+            | Let(Ident.StartsWith "second", next, Lambda(Ident.StartsWith "builder", Sequential(TypeCast(textBody, Unit) :: _), _)) ->
+                Children.get (textBody :: current) next
+            | CurriedApply(Lambda(Ident.StartsWith "cont", TypeCast(lastParameter, Unit), Some second), _, _, _) when second.StartsWith "second" ->
+                lastParameter :: current
+            | CurriedApply(Lambda(Ident.StartsWith "builder", Sequential [ TypeCast(middleParameter, Unit); next ], _), _, _, _)
+            | Lambda(Ident.StartsWith "builder", Sequential [ TypeCast(middleParameter, Unit); next ], _) ->
+                Children.get (middleParameter :: current) next
+            | Let(Ident.StartsWith "first", next1, Lambda(Ident.StartsWith "builder", Sequential [ CurriedApply _; next2 ], _)) ->
+                let next2Children = Children.get [] next2
+                let next1Children = Children.get [] next1
+                next2Children @ next1Children @ current
+            | Let(Ident.StartsWith "first", Let(_, expr, _), Let(Ident.StartsWith "second", next, _))
+            | Let(Ident.StartsWith "first", expr, Let(Ident.StartsWith "second", next, _)) ->
+                match expr with
+                | Let.NoChildrenNoProps builder ->
+                    Children.get (TagBuilder.transform builder :: current) next
+                | Tag.NoChildren builder ->
+                    TagBuilder.transform (builder |> TagBuilder.info (TagBuilderInfo.create []))
+                    |> fun newExpr -> Children.get (newExpr :: current) next
+                | Tag.WithChildren builder ->
+                    TagBuilder.transform builder
+                    |> fun newExpr -> Children.get (newExpr :: current) next
+                | _ ->
+                    Children.get (transform expr :: current) next
+            | IfThenElse(guardExpr, thenExpr, elseExpr, range) ->
+                IfThenElse(guardExpr, transform thenExpr, transform elseExpr, range) :: current
+            | DecisionTree(decisionTree, targets) ->
+                DecisionTree(decisionTree, targets |> List.map(fun (target,expr) -> target, transform expr)) :: current
+            | Call(Get(IdentExpr _, FieldGet _, Any, _), { Args = args }, _, _) ->
+                match args with
+                | [ Call(Import({Selector = "uncurry2"}, Any, None), { Args = [ Lambda(_, body, _) ] }, _, _) ] ->
+                    Children.get current body
+                | [ Call.TagImport (imp, _) ] ->
+                    TagBuilder.transform (TagBuilder.create (LibraryImport imp, TagBuilderInfo.create []))
+                    |> fun newExpr -> newExpr :: current
+                | [ Let(_, Call.TagImport(imp, _), Sequential exprs) ] ->
+                    TagBuilder.transform (TagBuilder.create (LibraryImport imp, TagBuilderInfo.create exprs))
+                    |> fun newExpr -> newExpr :: current
+                | [ Let(_, Let(_, Call.TagImport(imp, _), Sequential exprs), Tag.WithChildren { Info = TagBuilderInfo.Children callInfo }) ] ->
+                    TagBuilder.create ((LibraryImport imp), (TagBuilderInfo.create(exprs, callInfo)))
+                    |> TagBuilder.transform
+                    |> fun newExpr -> newExpr :: current
+                | [ next1; next2 ] ->
+                    let next2Children = Children.get [] next2
+                    let next1Children = Children.get [] next1
+                    next2Children @ next1Children @ current
+                | [ expr ] -> expr :: current
+                | _ -> current
+            | Let({Name=name; Range=range; Type=DeclaredType({FullName = fullName}, [])}, _, _)
+                when (name.StartsWith("returnVal") && fullName.StartsWith("Oxpecker.Solid"))
+                || (name.StartsWith("element") && fullName.StartsWith("Oxpecker.Solid"))
+                |> not ->
+                match range with
+                | Some range -> failwith $"let binding inside HTML CE can't be converted"
+                | None -> failwith "let binding inside HTML CE can't be converted"
+            | _ -> current
+        let wrap childrenExpression =
+            Value(
+                kind = NewTuple(
+                    values = [
+                        Value(kind=StringConstant "children", range=None)
+                        TypeCast(childrenExpression, Type.Any)
+                    ],
+                    isStruct = false
+                    ),
+                range = None
+            )
+    module Helpers =
+        let convertListToExpr (exprs: Fable.Expr list) =
+            (Baked.emptyList, exprs)
+            ||> List.fold(fun acc prop ->
+                Value(kind = NewList(headAndTail = Some(prop, acc), typ = Baked.listItemType), range = None))
+
+    let transform expr =
         match expr with
-        | LetTagNoChildrenWithProps tagCall
-        | LetElement & Let(_, LetTagNoChildrenWithProps tagCall, _) -> transformTagInfo tagCall
-        | TagNoChildren(tagName, range) -> transformTagInfo(TagInfo.NoChildren(tagName, [], range))
-        | CallTagNoChildrenWithHandler tagCall -> transformTagInfo tagCall
-        | LetTagNoChildrenNoProps tagCall -> transformTagInfo tagCall
-        | TagWithChildren callInfo -> transformTagInfo(TagInfo.WithChildren callInfo)
-        | LetTagWithChildren tagCall -> transformTagInfo tagCall
-        | LibraryTagImport(imp, range) -> transformTagInfo(TagInfo.NoChildren(LibraryImport imp, [], range))
-        | Let(_, LibraryTagImport(imp, range), TagWithChildren(_, callInfo, _)) ->
-            transformTagInfo(TagInfo.WithChildren(LibraryImport imp, callInfo, range))
-        | Let(_, LibraryTagImport(imp, range), Sequential exprs) ->
-            transformTagInfo(TagInfo.NoChildren(LibraryImport imp, exprs, range))
-        | Let(_, Let(_, LibraryTagImport(imp, range), Sequential exprs), TagWithChildren(_, callInfo, _)) ->
-            transformTagInfo(TagInfo.Combined(LibraryImport imp, exprs, callInfo, range))
-        | Let(name, value, expr) -> Let(name, value, (transform expr))
+        | Let.NoChildrenWithProps builder
+        | Let.Element & Let(_, Let.NoChildrenWithProps builder, _) -> builder |> TagBuilder.transform
+        | Tag.NoChildren builder ->
+            builder
+            |> TagBuilder.info (TagBuilderInfo.create [])
+            |> TagBuilder.transform
+        | Tag.NoChildrenWithHandler builder
+        | Let.NoChildrenNoProps builder
+        | Tag.WithChildren builder
+        | Let.WithChildren builder -> builder |> TagBuilder.transform
+        | Call.TagImport (tagSource, range) ->
+            TagBuilder.create (LibraryImport tagSource, TagBuilderInfo.create [], range)
+            |>  TagBuilder.transform
+        | Let(_, Call.TagImport(tagSource, range), Tag.WithChildren builder) ->
+            builder
+            |> TagBuilder.tag (LibraryImport tagSource)
+            |> TagBuilder.range range
+            |> TagBuilder.transform
+        | Let(_, Call.TagImport(tagSource, range), Sequential exprs) ->
+            TagBuilder.create (LibraryImport tagSource, TagBuilderInfo.create exprs, range)
+            |> TagBuilder.transform
+        | Let(_, Let(_, Call.TagImport(tagSource, range), Sequential exprs), Tag.WithChildren builder) ->
+            builder
+            |> TagBuilder.range range
+            |> TagBuilder.tag (LibraryImport tagSource)
+            |> TagBuilder.info.adds exprs
+            |> TagBuilder.transform
         | Sequential expressions ->
-            // transform only the last expression
-            Sequential(
+            Sequential (
                 expressions
                 |> List.mapi(fun i expr -> if i = expressions.Length - 1 then transform expr else expr)
             )
-        // transform children passed to component function call
         | Call(callee, callInfo, typ, range) ->
-            let newCallInfo = {
-                callInfo with
-                    Args = callInfo.Args |> List.map transform
+            {
+                callInfo with Args = callInfo.Args |> List.map transform
             }
-            Call(callee, newCallInfo, typ, range)
-        | TextNoSiblings body -> body
+            |> fun callInfo -> Call(callee, callInfo, typ, range)
+        | Lambda.TextNoSiblings body -> body
         | IfThenElse(guardExpr, thenExpr, elseExpr, range) ->
             IfThenElse(guardExpr, transform thenExpr, transform elseExpr, range)
         | DecisionTree(decisionTree, targets) ->
@@ -481,11 +485,11 @@ module internal rec AST =
                 ),
                 None
             )
-        let text = wrapChildrenExpression childrenExpression
+        let text = Children.wrap childrenExpression
         let finalList = text :: []
-        let propsExpr = convertExprListToExpr finalList
+        let propsExpr = Helpers.convertListToExpr finalList
         Call(
-            callee = importJsxCreate,
+            callee = Baked.importJsxCreate,
             info = {
                 ThisArg = None
                 Args = [ Value(StringConstant "h1", None); propsExpr ]
@@ -494,10 +498,10 @@ module internal rec AST =
                 MemberRef = None
                 Tags = [ "jsx" ]
             },
-            typ = jsxElementType,
+            typ = Baked.jsxElementType,
             range = range
         )
-
+open FSharp.Json
 /// <summary>
 /// Registers a function as a SolidComponent for transformation by
 /// the <c>Oxpecker.Solid.FablePlugin</c>
@@ -508,9 +512,8 @@ type SolidComponentAttribute() =
     override _.FableMinimumVersion = "4.0"
 
     override this.Transform(pluginHelper: PluginHelper, file: File, memberDecl: MemberDecl) =
-        // Console.WriteLine("!Start! MemberDecl")
-        // Console.WriteLine(memberDecl.Body)
-        // Console.WriteLine("!End! MemberDecl")
+        Console.ForegroundColor <- ConsoleColor.Cyan
+        Console.WriteLine memberDecl.Body
         let newBody =
             match memberDecl.Body with
             | Extended(Throw _, range) -> AST.transformException pluginHelper range


### PR DESCRIPTION
An attempt at chunking the plugin into more distinct pieces and threading a builder record through it so that it can facilitate tracing its journey through the transformations for debugging purposes (only on debug build)

WIP

- [x] First pass rewrite
- [x] Tracer implementation
- [ ] Helpers
- [ ] ?Visualisation?