### PR TITLE
Tracer and fix for LibraryImports

### DIFF
--- a/src/Oxpecker.Solid.FablePlugin/Library.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Library.fs
@@ -5,8 +5,6 @@ open Fable
 open Fable.AST
 open Fable.AST.Fable
 open Oxpecker.Solid.FablePlugin
-open Fable.Plugin.Tracer
-
 
 [<assembly: ScanForPlugins>]
 do () // Prompts fable to utilise this plugin

--- a/src/Oxpecker.Solid.FablePlugin/Library.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Library.fs
@@ -17,51 +17,81 @@ module TraceSettings =
 module internal rec AST =
     let private _random = Random()
 
-    type Tracer<'T> =
-        {
-            Value : 'T
-            Guid : Guid
-            ConsoleColor : ConsoleColor
-        }
+    type Tracer<'T> = {
+        Value: 'T
+        Guid: Guid
+        ConsoleColor: ConsoleColor
+    } with
         member this.emit(message: string, memberName: string, path: string, line: int) =
-            if verbose() |> not then this
+            if verbose() |> not then
+                this
             else
-            Console.ForegroundColor <- this.ConsoleColor
-            Console.Write $"{this.Guid} "
-            Console.ForegroundColor <- ConsoleColor.Gray
-            Console.Write $"{memberName, -20}"
-            Console.ResetColor()
-            Console.WriteLine $"{message} ({path}:{line})"
-            this
-        member this.trace (
-            [<Runtime.InteropServices.Optional; Runtime.InteropServices.DefaultParameterValue("")>] message : string,
-            [<Runtime.InteropServices.Optional; Runtime.CompilerServices.CallerMemberName; Runtime.InteropServices.DefaultParameterValue("")>] memberName : string,
-            [<Runtime.CompilerServices.CallerFilePath; Runtime.InteropServices.Optional; Runtime.InteropServices.DefaultParameterValue("")>] path : string,
-            [<Runtime.CompilerServices.CallerLineNumber; Runtime.InteropServices.Optional; Runtime.InteropServices.DefaultParameterValue(0)>] line : int
-        ) = this.emit(message, memberName, path, line)
-        member this.ping (
-            [<Runtime.InteropServices.Optional; Runtime.InteropServices.DefaultParameterValue("")>] message : string,
-            [<Runtime.InteropServices.Optional; Runtime.CompilerServices.CallerMemberName; Runtime.InteropServices.DefaultParameterValue("")>] memberName : string,
-            [<Runtime.CompilerServices.CallerFilePath; Runtime.InteropServices.Optional; Runtime.InteropServices.DefaultParameterValue("")>] path : string,
-            [<Runtime.CompilerServices.CallerLineNumber; Runtime.InteropServices.Optional; Runtime.InteropServices.DefaultParameterValue(0)>] line : int
-        ) = this.emit(message, memberName, path, line) |> ignore
+                Console.ForegroundColor <- this.ConsoleColor
+                Console.Write $"{this.Guid} "
+                Console.ForegroundColor <- ConsoleColor.Gray
+                Console.Write $"{memberName, -20}"
+                Console.ResetColor()
+                Console.WriteLine $"{message} ({path}:{line})"
+                this
+        member this.trace
+            (
+                [<Runtime.InteropServices.Optional; Runtime.InteropServices.DefaultParameterValue("")>] message: string,
+                [<Runtime.InteropServices.Optional;
+                  Runtime.CompilerServices.CallerMemberName;
+                  Runtime.InteropServices.DefaultParameterValue("")>] memberName: string,
+                [<Runtime.CompilerServices.CallerFilePath;
+                  Runtime.InteropServices.Optional;
+                  Runtime.InteropServices.DefaultParameterValue("")>] path: string,
+                [<Runtime.CompilerServices.CallerLineNumber;
+                  Runtime.InteropServices.Optional;
+                  Runtime.InteropServices.DefaultParameterValue(0)>] line: int
+            ) =
+            this.emit(message, memberName, path, line)
+        member this.ping
+            (
+                [<Runtime.InteropServices.Optional; Runtime.InteropServices.DefaultParameterValue("")>] message: string,
+                [<Runtime.InteropServices.Optional;
+                  Runtime.CompilerServices.CallerMemberName;
+                  Runtime.InteropServices.DefaultParameterValue("")>] memberName: string,
+                [<Runtime.CompilerServices.CallerFilePath;
+                  Runtime.InteropServices.Optional;
+                  Runtime.InteropServices.DefaultParameterValue("")>] path: string,
+                [<Runtime.CompilerServices.CallerLineNumber;
+                  Runtime.InteropServices.Optional;
+                  Runtime.InteropServices.DefaultParameterValue(0)>] line: int
+            ) =
+            this.emit(message, memberName, path, line) |> ignore
     module Tracer =
-        let inline private _create value guid consoleColor = { Value = value; Guid = guid; ConsoleColor = consoleColor }
+        let inline private _create value guid consoleColor = {
+            Value = value
+            Guid = guid
+            ConsoleColor = consoleColor
+        }
         let create value =
-            if verbose() |> not then _create value Guid.Empty ConsoleColor.Black
+            if verbose() |> not then
+                _create value Guid.Empty ConsoleColor.Black
             else
-            _random.Next(15)
-            |> enum<ConsoleColor>
-            |> _create value (Guid.NewGuid())
+                _random.Next(15) |> enum<ConsoleColor> |> _create value (Guid.NewGuid())
         let init = _create () Guid.Empty ConsoleColor.Black
-        let map (tracer: Tracer<'T>) (input: 'M): Tracer<'M> = _create input tracer.Guid tracer.ConsoleColor
-        let (|Traced|) (tracer : Tracer<'T>) = (tracer.Value, tracer)
-        let trace (
-            [<Runtime.InteropServices.Optional; Runtime.InteropServices.DefaultParameterValue("")>] message : string,
-            [<Runtime.InteropServices.Optional; Runtime.CompilerServices.CallerMemberName; Runtime.InteropServices.DefaultParameterValue("")>] memberName : string,
-            [<Runtime.CompilerServices.CallerFilePath; Runtime.InteropServices.Optional; Runtime.InteropServices.DefaultParameterValue("")>] path : string,
-            [<Runtime.CompilerServices.CallerLineNumber; Runtime.InteropServices.Optional; Runtime.InteropServices.DefaultParameterValue(0)>] line : int
-            ) (tracer: Tracer<'a>)= tracer.emit(message, memberName, path, line)
+        let map (tracer: Tracer<'T>) (input: 'M) : Tracer<'M> =
+            _create input tracer.Guid tracer.ConsoleColor
+        let (|Traced|) (tracer: Tracer<'T>) = (tracer.Value, tracer)
+        let trace
+            (
+                [<Runtime.InteropServices.Optional; Runtime.InteropServices.DefaultParameterValue("")>] message: string,
+                [<Runtime.InteropServices.Optional;
+                  Runtime.CompilerServices.CallerMemberName;
+                  Runtime.InteropServices.DefaultParameterValue("")>] memberName: string,
+                [<Runtime.CompilerServices.CallerFilePath;
+                  Runtime.InteropServices.Optional;
+                  Runtime.InteropServices.DefaultParameterValue("")>] path: string,
+                [<Runtime.CompilerServices.CallerLineNumber;
+                  Runtime.InteropServices.Optional;
+                  Runtime.InteropServices.DefaultParameterValue(0)>] line: int
+            )
+            (tracer: Tracer<'a>)
+            =
+            tracer.emit(message, memberName, path, line)
 
     /// <summary>
     /// AST Representation for a JSX Attribute/property. Tuple of name and value
@@ -85,25 +115,56 @@ module internal rec AST =
         | Combined of tagName: TagSource * props: Expr list * propsAndChildren: CallInfo * range: SourceLocation option
     [<AutoOpen>]
     module Native =
-        let (|StartsWith|_|) (value: string) : string -> unit option = function | s when s.StartsWith(value) -> Some() | _ -> None
-        let (|EndsWith|_|) (value: string) : string -> unit option = function | s when s.EndsWith(value) -> Some() | _ -> None
-        let (|Equals|_|) (value: string) : string -> unit option = function | s when s.Equals(value) -> Some() | _ -> None
-        let (|Trim|) (value: int) (input: string) = input.Substring(0, input.Length - value)
+        let (|StartsWith|_|) (value: string) : string -> unit option =
+            function
+            | s when s.StartsWith(value) -> Some()
+            | _ -> None
+        let (|EndsWith|_|) (value: string) : string -> unit option =
+            function
+            | s when s.EndsWith(value) -> Some()
+            | _ -> None
+        let (|Equals|_|) (value: string) : string -> unit option =
+            function
+            | s when s.Equals(value) -> Some()
+            | _ -> None
+        let (|Trim|) (value: int) (input: string) =
+            input.Substring(0, input.Length - value)
     [<RequireQualifiedAccess>]
     module EntityRef =
-        let (|StartsWith|_|) (value : string) = function | e when e.FullName.StartsWith value -> Some() | _ -> None
+        let (|StartsWith|_|) (value: string) =
+            function
+            | e when e.FullName.StartsWith value -> Some()
+            | _ -> None
     [<RequireQualifiedAccess>]
     module Ident =
-        let (|StartsWith|_|) (value : string) : Ident -> unit option = function | i when i.Name.StartsWith value -> Some() | _ -> None
+        let (|StartsWith|_|) (value: string) : Ident -> unit option =
+            function
+            | i when i.Name.StartsWith value -> Some()
+            | _ -> None
     [<RequireQualifiedAccess>]
     module ImportInfo =
-        let (|StartsWith|_|) (value : string) = function | i when i.Selector.StartsWith value -> Some() | _ -> None
-        let (|Equals|_|) (value: string) = function | i when i.Selector = value -> Some() | _ -> None
+        let (|StartsWith|_|) (value: string) =
+            function
+            | i when i.Selector.StartsWith value -> Some()
+            | _ -> None
+        let (|Equals|_|) (value: string) =
+            function
+            | i when i.Selector = value -> Some()
+            | _ -> None
     [<RequireQualifiedAccess>]
     module Import =
-        let (|Info|_|) = function | Import(value,_,_) -> Some value | _ -> None
-        let (|Type|_|) = function | Import(_,value,_) -> Some value | _ -> None
-        let (|Range|_|) = function | Import(_,_,value) -> Some value | _ -> None
+        let (|Info|_|) =
+            function
+            | Import(value, _, _) -> Some value
+            | _ -> None
+        let (|Type|_|) =
+            function
+            | Import(_, value, _) -> Some value
+            | _ -> None
+        let (|Range|_|) =
+            function
+            | Import(_, _, value) -> Some value
+            | _ -> None
     [<RequireQualifiedAccess>]
     module Call =
         /// <summary>
@@ -112,8 +173,10 @@ module internal rec AST =
         /// <returns><c>Expr * SourceLocation</c></returns>
         let (|ImportTag|_|) (expr: Expr) =
             match expr with
-            | Call(Import({ Kind = UserImport false }, Any, _) as imp, CallInfo.GetTags [ "new" ], DeclaredType(EntityRef.StartsWith "Oxpecker.Solid", []), range) ->
-                Some(imp, range)
+            | Call(Import({ Kind = UserImport false }, Any, _) as imp,
+                   CallInfo.GetTags [ "new" ],
+                   DeclaredType(EntityRef.StartsWith "Oxpecker.Solid", []),
+                   range) -> Some(imp, range)
             | _ -> None
         /// <summary>
         /// Pattern matches expressions for Tags calls.
@@ -123,7 +186,9 @@ module internal rec AST =
         /// <returns><c>TagSource * CallInfo * SourceLocation option</c></returns>
         let (|Tag|_|) condition =
             function
-            | Call(Import(importInfo, LambdaType(_, DeclaredType(typ, _)), _), callInfo, _, range) when condition importInfo ->
+            | Call(Import(importInfo, LambdaType(_, DeclaredType(typ, _)), _), callInfo, _, range) when
+                condition importInfo
+                ->
                 let tagImport =
                     match callInfo.Args with
                     | Call.ImportTag(imp, _) :: _
@@ -132,8 +197,8 @@ module internal rec AST =
                         let tagName = typ.FullName.Split('.') |> Seq.last
                         match tagName with
                         | "Fragment" -> ""
-                        | EndsWith "'" & Trim(1) s -> s
-                        | EndsWith "`1" & Trim(2) s -> s
+                        | EndsWith "'" & Trim (1) s -> s
+                        | EndsWith "`1" & Trim (2) s -> s
                         | _ -> tagName
                         |> AutoImport
                 Some(tagImport, callInfo, range)
@@ -167,16 +232,25 @@ module internal rec AST =
             | _ -> None
     [<RequireQualifiedAccess>]
     module Let =
-        let (|Ident|_|) = function | Let(value,_,_) -> Some value | _ -> None
-        let (|Value|_|) = function | Let(_,value,_) -> Some value | _ -> None
-        let (|Body|_|) = function | Let(_,_,value) -> Some value | _ -> None
+        let (|Ident|_|) =
+            function
+            | Let(value, _, _) -> Some value
+            | _ -> None
+        let (|Value|_|) =
+            function
+            | Let(_, value, _) -> Some value
+            | _ -> None
+        let (|Body|_|) =
+            function
+            | Let(_, _, value) -> Some value
+            | _ -> None
         /// <summary>
         /// Pattern matches <c>let</c> bindings that start with <c>element</c>
         /// </summary>
         /// <returns><c>unit</c></returns>
         let (|Element|_|) =
             function
-            | Let.Ident (Ident.StartsWith "element") -> Some()
+            | Let.Ident(Ident.StartsWith "element") -> Some()
             | _ -> None
         /// <summary>
         /// Pattern matches <c>let</c> bindings for Tags with children
@@ -184,7 +258,8 @@ module internal rec AST =
         /// <returns><c>TagInfo.WithChildren</c></returns>
         let (|TagWithChildren|_|) =
             function
-            | Let.Value (Tag.WithChildren(tagName, callInfo, range)) -> TagInfo.WithChildren(tagName, callInfo, range) |> Some
+            | Let.Value(Tag.WithChildren(tagName, callInfo, range)) ->
+                TagInfo.WithChildren(tagName, callInfo, range) |> Some
             | _ -> None
         /// <summary>
         /// Pattern matches <c>let</c> bindings for Tags without children (but with props)
@@ -192,7 +267,8 @@ module internal rec AST =
         /// <returns><c>TagInfo.NoChildren</c></returns>
         let (|TagNoChildrenWithProps|_|) =
             function
-            | Let(_, Tag.NoChildren(tagName, range), Sequential exprs) -> TagInfo.NoChildren(tagName, exprs, range) |> Some
+            | Let(_, Tag.NoChildren(tagName, range), Sequential exprs) ->
+                TagInfo.NoChildren(tagName, exprs, range) |> Some
             | _ -> None
     /// <summary>
     /// Pattern matches expressions (<c>let</c> or otherwise) for tags without children directly to Tag calls
@@ -200,11 +276,10 @@ module internal rec AST =
     /// <returns><c>TagInfo.NoChildren</c></returns>
     let (|CallTagNoChildrenWithHandler|_|) (expr: Expr) =
         match expr with
-        | Call(Import.Info (ImportInfo.StartsWith "HtmlElementExtensions_"), CallInfo.GetArgs(args :: _), _, range) ->
-            (args,range)
+        | Call(Import.Info(ImportInfo.StartsWith "HtmlElementExtensions_"), CallInfo.GetArgs(args :: _), _, range) ->
+            (args, range)
             |> function
-                | Tag.NoChildren(tagName, _), range ->
-                    TagInfo.NoChildren(tagName, [ expr ], range) |> Some
+                | Tag.NoChildren(tagName, _), range -> TagInfo.NoChildren(tagName, [ expr ], range) |> Some
                 | Let.TagNoChildrenWithProps(NoChildren(tagName, props, _)), range ->
                     TagInfo.NoChildren(tagName, expr :: props, range) |> Some
                 | CallTagNoChildrenWithHandler(NoChildren(tagName, props, _)), range ->
@@ -217,7 +292,7 @@ module internal rec AST =
     /// <returns><c>TagInfo.NoChildren</c></returns>
     let (|LetTagNoChildrenNoProps|_|) =
         function
-        | Let.Value (Tag.NoChildren(tagName, range)) -> TagInfo.NoChildren(tagName, [], range) |> Some
+        | Let.Value(Tag.NoChildren(tagName, range)) -> TagInfo.NoChildren(tagName, [], range) |> Some
         | _ -> None
     /// <summary>
     /// Pattern matches expressions that are text in isolation (no siblings)
@@ -234,20 +309,26 @@ module internal rec AST =
         | _ -> None
     [<AutoOpen>]
     module Attributes =
-        let (|Extension|_|) = function
+        let (|Extension|_|) =
+            function
             | "on", EventHandler(eventName, handler), restResults -> ("on:" + eventName, handler) :: restResults |> Some
-            | "bool", EventHandler(eventName, handler), restResults -> ("bool:" + eventName, handler) :: restResults |> Some
-            | "data", EventHandler(eventName, handler), restResults -> ("data-" + eventName, handler) :: restResults |> Some
+            | "bool", EventHandler(eventName, handler), restResults ->
+                ("bool:" + eventName, handler) :: restResults |> Some
+            | "data", EventHandler(eventName, handler), restResults ->
+                ("data-" + eventName, handler) :: restResults |> Some
             | "attr", EventHandler(eventName, handler), restResults -> (eventName, handler) :: restResults |> Some
             | "ref", CallInfo.GetArgs [ _; identExpr ], restResults -> ("ref", identExpr) :: restResults |> Some
             | "style'", CallInfo.GetArgs [ _; identExpr ], restResults -> ("style", identExpr) :: restResults |> Some
-            | "classList", CallInfo.GetArgs [ _; identExpr ], restResults -> ("classList", identExpr) :: restResults |> Some
+            | "classList", CallInfo.GetArgs [ _; identExpr ], restResults ->
+                ("classList", identExpr) :: restResults |> Some
             | _ -> None
         let rec collectAttributes (tracer: Expr list Tracer) =
             let exprs = tracer.Value
             match exprs with
             | [] -> []
-            | Sequential expressions :: rest -> (Tracer.map tracer >> collectAttributes) rest @ (Tracer.map tracer >> collectAttributes) expressions
+            | Sequential expressions :: rest ->
+                (Tracer.map tracer >> collectAttributes) rest
+                @ (Tracer.map tracer >> collectAttributes) expressions
             | Call(Import.Info importInfo, callInfo, _, _) :: rest ->
                 let restResults = (Tracer.map tracer >> collectAttributes) rest
                 match importInfo.Kind with
@@ -288,8 +369,9 @@ module internal rec AST =
             let expr = tracer.Value
             match expr with
             | Let(Ident.StartsWith "returnVal", _, Sequential exprs) ->
-                (Tracer.map (tracer.trace()) >> collectAttributes) exprs @ currentList
-            | CallTagNoChildrenWithHandler(NoChildren(_, props, _)) -> (Tracer.map (tracer.trace()) >> collectAttributes) props @ currentList
+                (Tracer.map(tracer.trace()) >> collectAttributes) exprs @ currentList
+            | CallTagNoChildrenWithHandler(NoChildren(_, props, _)) ->
+                (Tracer.map(tracer.trace()) >> collectAttributes) props @ currentList
             | _ -> currentList
     [<AutoOpen>]
     module Children =
@@ -297,16 +379,16 @@ module internal rec AST =
             let expr = tracer.trace().Value
             match expr with
             | Let.TagWithChildren tagInfo ->
-                let newExpr = transformTagInfo (tagInfo |> Tracer.create)
+                let newExpr = transformTagInfo(tagInfo |> Tracer.create)
                 newExpr :: currentList
-            | Let.Element & Let.Value (Let.TagNoChildrenWithProps tagInfo) ->
-                let newExpr = transformTagInfo (tagInfo |> Tracer.create)
+            | Let.Element & Let.Value(Let.TagNoChildrenWithProps tagInfo) ->
+                let newExpr = transformTagInfo(tagInfo |> Tracer.create)
                 newExpr :: currentList
             | Let.Element & LetTagNoChildrenNoProps tagInfo ->
-                let newExpr = transformTagInfo (tagInfo |> Tracer.create)
+                let newExpr = transformTagInfo(tagInfo |> Tracer.create)
                 newExpr :: currentList
-            | Let.Element & Let.Value (CallTagNoChildrenWithHandler tagInfo) ->
-                let newExpr = transformTagInfo (tagInfo |> Tracer.create)
+            | Let.Element & Let.Value(CallTagNoChildrenWithHandler tagInfo) ->
+                let newExpr = transformTagInfo(tagInfo |> Tracer.create)
                 newExpr :: currentList
             | Let.Element & Let.Value next ->
                 let newExpr = transform next
@@ -318,16 +400,25 @@ module internal rec AST =
             // text with solid signals inside
             | Let(Ident.StartsWith "text", body, TextNoSiblings _) -> body :: currentList
             // text then tag
-            | Let(Ident.StartsWith "second", next, Lambda(Ident.StartsWith "builder", Sequential(TypeCast(textBody, Unit) :: _), _)) ->
+            | Let(Ident.StartsWith "second",
+                  next,
+                  Lambda(Ident.StartsWith "builder", Sequential(TypeCast(textBody, Unit) :: _), _)) ->
                 getChildren (textBody :: currentList) (Tracer.map tracer next)
             // parameter then another parameter
-            | CurriedApply(Lambda(Ident.StartsWith "cont", TypeCast(lastParameter, Unit), Some (StartsWith "second")), _, _, _) ->
-                lastParameter :: currentList
-            | CurriedApply(Lambda(Ident.StartsWith "builder", Sequential [ TypeCast(middleParameter, Unit); next ], _), _, _, _)
+            | CurriedApply(Lambda(Ident.StartsWith "cont", TypeCast(lastParameter, Unit), Some(StartsWith "second")),
+                           _,
+                           _,
+                           _) -> lastParameter :: currentList
+            | CurriedApply(Lambda(Ident.StartsWith "builder", Sequential [ TypeCast(middleParameter, Unit); next ], _),
+                           _,
+                           _,
+                           _)
             | Lambda(Ident.StartsWith "builder", Sequential [ TypeCast(middleParameter, Unit); next ], _) ->
                 getChildren (middleParameter :: currentList) (Tracer.map tracer next)
             // tag then text
-            | Let(Ident.StartsWith "first", next1, Lambda(Ident.StartsWith "builder", Sequential [ CurriedApply _; next2 ], _)) ->
+            | Let(Ident.StartsWith "first",
+                  next1,
+                  Lambda(Ident.StartsWith "builder", Sequential [ CurriedApply _; next2 ], _)) ->
                 let next2Children = getChildren [] (Tracer.map tracer next2)
                 let next1Children = getChildren [] (Tracer.map tracer next1)
                 next2Children @ next1Children @ currentList
@@ -335,10 +426,11 @@ module internal rec AST =
             | Let(Ident.StartsWith "first", expr, Let(Ident.StartsWith "second", next, _)) ->
                 match expr with
                 | Let.TagNoChildrenWithProps tagInfo ->
-                    let newExpr = transformTagInfo (tagInfo |> Tracer.create)
+                    let newExpr = transformTagInfo(tagInfo |> Tracer.create)
                     getChildren (newExpr :: currentList) (Tracer.map tracer next)
                 | Tag.NoChildren(tagName, range) ->
-                    let newExpr = transformTagInfo(TagInfo.NoChildren(tagName, [], range) |> Tracer.create)
+                    let newExpr =
+                        transformTagInfo(TagInfo.NoChildren(tagName, [], range) |> Tracer.create)
                     getChildren (newExpr :: currentList) (Tracer.map tracer next)
                 | Tag.WithChildren callInfo ->
                     let newExpr = transformTagInfo(TagInfo.WithChildren callInfo |> Tracer.create)
@@ -358,10 +450,12 @@ module internal rec AST =
                 | [ Call(Import(ImportInfo.Equals "uncurry2", Any, None), { Args = [ Lambda(_, body, _) ] }, _, _) ] ->
                     getChildren currentList (Tracer.map tracer body)
                 | [ Call.ImportTag(imp, _) ] ->
-                    let newExpr = transformTagInfo(TagInfo.NoChildren(LibraryImport imp, [], None) |> Tracer.create)
+                    let newExpr =
+                        transformTagInfo(TagInfo.NoChildren(LibraryImport imp, [], None) |> Tracer.create)
                     newExpr :: currentList
                 | [ Let(_, Call.ImportTag(imp, _), Sequential exprs) ] ->
-                    let newExpr = transformTagInfo(TagInfo.NoChildren(LibraryImport imp, exprs, None) |> Tracer.create)
+                    let newExpr =
+                        transformTagInfo(TagInfo.NoChildren(LibraryImport imp, exprs, None) |> Tracer.create)
                     newExpr :: currentList
                 | [ Let(_, Let(_, Call.ImportTag(imp, _), Sequential exprs), Tag.WithChildren(_, callInfo, _)) ] ->
                     let newExpr =
@@ -373,13 +467,15 @@ module internal rec AST =
                     next2Children @ next1Children @ currentList
                 | [ expr ] -> expr :: currentList
                 | _ -> currentList
-            | Let.Ident { Name = name
-                          Range = range
-                          Type = DeclaredType(EntityRef.StartsWith "Oxpecker.Solid", []) }
-                when not (name.StartsWith("returnVal") || name.StartsWith("element")) ->
-                    match range with
-                    | Some range -> failwith $"`let` binding inside HTML CE can't be converted to JSX:line {range.start.line}"
-                    | None -> failwith $"`let` binding inside HTML CE can't be converted to JSX"
+            | Let.Ident {
+                            Name = name
+                            Range = range
+                            Type = DeclaredType(EntityRef.StartsWith "Oxpecker.Solid", [])
+                        } when not(name.StartsWith("returnVal") || name.StartsWith("element")) ->
+                match range with
+                | Some range ->
+                    failwith $"`let` binding inside HTML CE can't be converted to JSX:line {range.start.line}"
+                | None -> failwith $"`let` binding inside HTML CE can't be converted to JSX"
             | _ -> currentList
     [<RequireQualifiedAccess>]
     module Baked =
@@ -436,12 +532,14 @@ module internal rec AST =
 
     let transformTagInfo (tracer: TagInfo Tracer) : Expr =
         tracer.ping()
-        let tagInfo= tracer.Value
+        let tagInfo = tracer.Value
         let tagName, props, children, range =
             match tagInfo with
             | WithChildren(tagName, callInfo, range) ->
-                let props = callInfo.Args |> List.map (Tracer.map tracer) |> List.fold getAttributes []
-                let childrenList = callInfo.Args |> List.map (Tracer.map tracer) |> List.fold getChildren []
+                let props =
+                    callInfo.Args |> List.map(Tracer.map tracer) |> List.fold getAttributes []
+                let childrenList =
+                    callInfo.Args |> List.map(Tracer.map tracer) |> List.fold getChildren []
                 tagName, props, childrenList, range
             | NoChildren(tagName, propList, range) ->
                 let props = propList |> Tracer.map tracer |> collectAttributes
@@ -449,7 +547,8 @@ module internal rec AST =
                 tagName, props, childrenList, range
             | Combined(tagName, propList, callInfo, range) ->
                 let props = propList |> Tracer.map tracer |> collectAttributes
-                let childrenList = callInfo.Args |> List.map (Tracer.map tracer) |> List.fold getChildren []
+                let childrenList =
+                    callInfo.Args |> List.map(Tracer.map tracer) |> List.fold getChildren []
                 tagName, props, childrenList, range
 
         let propsXs =
@@ -496,19 +595,34 @@ module internal rec AST =
         let expr = tracer.Value
         match expr with
         | Let.TagNoChildrenWithProps tagCall
-        | Let.Element & Let(_, Let.TagNoChildrenWithProps tagCall, _) -> transformTagInfo (tagCall |> Tracer.create |> _.trace() )
-        | Tag.NoChildren(tagName, range) -> transformTagInfo(TagInfo.NoChildren(tagName, [], range) |> Tracer.create |> _.trace() )
-        | CallTagNoChildrenWithHandler tagCall -> transformTagInfo (tagCall |> Tracer.create |> _.trace() )
-        | LetTagNoChildrenNoProps tagCall -> transformTagInfo (tagCall |> Tracer.create |> _.trace() )
+        | Let.Element & Let(_, Let.TagNoChildrenWithProps tagCall, _) ->
+            transformTagInfo(tagCall |> Tracer.create |> _.trace())
+        | Tag.NoChildren(tagName, range) ->
+            transformTagInfo(TagInfo.NoChildren(tagName, [], range) |> Tracer.create |> _.trace())
+        | CallTagNoChildrenWithHandler tagCall -> transformTagInfo(tagCall |> Tracer.create |> _.trace())
+        | LetTagNoChildrenNoProps tagCall -> transformTagInfo(tagCall |> Tracer.create |> _.trace())
         | Tag.WithChildren callInfo -> transformTagInfo(TagInfo.WithChildren callInfo |> Tracer.create |> _.trace())
-        | Let.TagWithChildren tagCall -> transformTagInfo (tagCall |> Tracer.create |> _.trace())
-        | Call.ImportTag(imp, range) -> transformTagInfo(TagInfo.NoChildren(LibraryImport imp, [], range) |> Tracer.create |> _.trace())
+        | Let.TagWithChildren tagCall -> transformTagInfo(tagCall |> Tracer.create |> _.trace())
+        | Call.ImportTag(imp, range) ->
+            transformTagInfo(TagInfo.NoChildren(LibraryImport imp, [], range) |> Tracer.create |> _.trace())
         | Let(_, Call.ImportTag(imp, range), Tag.WithChildren(_, callInfo, _)) ->
-            transformTagInfo(TagInfo.WithChildren(LibraryImport imp, callInfo, range) |> Tracer.create |> _.trace())
+            transformTagInfo(
+                TagInfo.WithChildren(LibraryImport imp, callInfo, range)
+                |> Tracer.create
+                |> _.trace()
+            )
         | Let(_, Call.ImportTag(imp, range), Sequential exprs) ->
-            transformTagInfo(TagInfo.NoChildren(LibraryImport imp, exprs, range) |> Tracer.create |> _.trace())
+            transformTagInfo(
+                TagInfo.NoChildren(LibraryImport imp, exprs, range)
+                |> Tracer.create
+                |> _.trace()
+            )
         | Let(_, Let(_, Call.ImportTag(imp, range), Sequential exprs), Tag.WithChildren(_, callInfo, _)) ->
-            transformTagInfo(TagInfo.Combined(LibraryImport imp, exprs, callInfo, range) |> Tracer.create |> _.trace())
+            transformTagInfo(
+                TagInfo.Combined(LibraryImport imp, exprs, callInfo, range)
+                |> Tracer.create
+                |> _.trace()
+            )
         | Let(name, value, expr) -> Let(name, value, (transform expr))
         | Sequential expressions ->
             // transform only the last expression
@@ -570,7 +684,8 @@ type SolidComponentAttribute() =
     override _.FableMinimumVersion = "4.0"
 
     override this.Transform(pluginHelper: PluginHelper, file: File, memberDecl: MemberDecl) =
-        if pluginHelper.Options.Verbosity = Verbosity.Verbose then enableTrace()
+        if pluginHelper.Options.Verbosity = Verbosity.Verbose then
+            enableTrace()
         // Console.WriteLine("!Start! MemberDecl")
         // Console.WriteLine(memberDecl.Body)
         // Console.WriteLine("!End! MemberDecl")

--- a/src/Oxpecker.Solid.FablePlugin/Library.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Library.fs
@@ -16,7 +16,7 @@ module TraceSettings =
     let enableTrace () = _verbose <- true
     let verbose () = _verbose
     type Tracer<'T> with
-        member this.emit(message: string, memberName: string, path: string, line: int) =
+        member this.emit(message: string, memberName: string, path: string, line: int, [<Runtime.InteropServices.Optional;Runtime.InteropServices.DefaultParameterValue(true)>] emitJson: bool) =
             if verbose() |> not then
                 this
             else
@@ -26,7 +26,7 @@ module TraceSettings =
                 Console.Write $"{memberName, -20}"
                 Console.ResetColor()
                 Console.WriteLine $"{message} ({path}:{line})"
-                if PluginConfiguration.Jsonify() then
+                if PluginConfiguration.Jsonify() && emitJson then
                     Console.WriteLine $"{PrettyPrinter.print this.Value}"
                 this
         member this.trace
@@ -57,6 +57,25 @@ module TraceSettings =
                   Runtime.InteropServices.DefaultParameterValue(0)>] line: int
             ) =
             this.emit(message, memberName, path, line) |> ignore
+        static member ping
+            (
+                [<Runtime.InteropServices.Optional; Runtime.InteropServices.DefaultParameterValue("")>] message: string,
+                [<Runtime.InteropServices.Optional;
+                  Runtime.CompilerServices.CallerMemberName;
+                  Runtime.InteropServices.DefaultParameterValue("")>] memberName: string,
+                [<Runtime.CompilerServices.CallerFilePath;
+                  Runtime.InteropServices.Optional;
+                  Runtime.InteropServices.DefaultParameterValue("")>] path: string,
+                [<Runtime.CompilerServices.CallerLineNumber;
+                  Runtime.InteropServices.Optional;
+                  Runtime.InteropServices.DefaultParameterValue(0)>] line: int
+            ) =
+            if verbose() then
+                Console.Write "                                     "
+                Console.ForegroundColor <- ConsoleColor.Gray
+                Console.Write $"{memberName, -20}"
+                Console.ResetColor()
+                Console.WriteLine $"{message} ({path}:{line})"
 module internal rec AST =
     module Tracer =
         let private _random = Random()
@@ -95,7 +114,9 @@ module internal rec AST =
     module Native =
         let (|StartsWith|_|) (value: string) : string -> unit option =
             function
-            | s when s.StartsWith(value) -> Some()
+            | s when s.StartsWith(value) ->
+                Tracer.ping($"Starts with {value}")
+                Some()
             | _ -> None
         let (|EndsWith|_|) (value: string) : string -> unit option =
             function
@@ -103,7 +124,7 @@ module internal rec AST =
             | _ -> None
         let (|Equals|_|) (value: string) : string -> unit option =
             function
-            | s when s.Equals(value) -> Some()
+            | s when s.Equals(value) -> Tracer.ping($"Equals {value}"); Some()
             | _ -> None
         let (|Trim|) (value: int) (input: string) =
             input.Substring(0, input.Length - value)
@@ -111,23 +132,29 @@ module internal rec AST =
     module EntityRef =
         let (|StartsWith|_|) (value: string) =
             function
-            | e when e.FullName.StartsWith value -> Some()
+            | e when e.FullName.StartsWith value -> Tracer.ping($"EntityRef Startswith {value}"); Some()
             | _ -> None
     [<RequireQualifiedAccess>]
     module Ident =
         let (|StartsWith|_|) (value: string) : Ident -> unit option =
             function
-            | i when i.Name.StartsWith value -> Some()
+            | i when i.Name.StartsWith value ->
+                Tracer.ping($"Ident starts with {value}")
+                Some()
             | _ -> None
     [<RequireQualifiedAccess>]
     module ImportInfo =
         let (|StartsWith|_|) (value: string) =
             function
-            | i when i.Selector.StartsWith value -> Some()
+            | i when i.Selector.StartsWith value ->
+                Tracer.ping($"ImportInfo selector startswith {value}")
+                Some()
             | _ -> None
         let (|Equals|_|) (value: string) =
             function
-            | i when i.Selector = value -> Some()
+            | i when i.Selector = value ->
+                Tracer.ping($"ImportInfo selector is equal to {value}")
+                Some()
             | _ -> None
     [<RequireQualifiedAccess>]
     module Import =
@@ -154,7 +181,7 @@ module internal rec AST =
             | Call(Import({ Kind = UserImport false }, Any, _) as imp,
                    CallInfo.GetTags [ "new" ],
                    DeclaredType(EntityRef.StartsWith "Oxpecker.Solid", []),
-                   range) -> Some(imp, range)
+                   range) -> Tracer.ping(); Some(imp, range)
             | _ -> None
         /// <summary>
         /// Pattern matches expressions for Tags calls.
@@ -170,8 +197,9 @@ module internal rec AST =
                 let tagImport =
                     match callInfo.Args with
                     | Call.ImportTag(imp, _) :: _
-                    | Let(_, Call.ImportTag(imp, _), _) :: _ -> LibraryImport imp
+                    | Let(_, Call.ImportTag(imp, _), _) :: _ -> Tracer.ping($"CallInfo.Args is Let(_, Call.ImportTag(imp, _), _) :: _ or Call.ImportTag(imp,_)::_"); LibraryImport imp
                     | _ ->
+                        Tracer.ping("AutoImport")
                         let tagName = typ.FullName.Split('.') |> Seq.last
                         match tagName with
                         | "Fragment" -> ""
@@ -194,7 +222,7 @@ module internal rec AST =
         let (|NoChildren|_|) (expr: Expr) =
             let condition = _.Selector.EndsWith("_$ctor")
             match expr with
-            | Call.Tag condition (tagName, _, range) -> Some(tagName, range)
+            | Call.Tag condition (tagName, _, range) -> Tracer.ping(); Some(tagName, range)
             | _ -> None
         /// <summary>
         /// Pattern matches expressions to Tag calls with children
@@ -206,7 +234,7 @@ module internal rec AST =
                     importInfo.Selector.StartsWith("HtmlContainerExtensions_Run")
                     || importInfo.Selector.StartsWith("BindingsModule_Extensions_Run")
             match expr with
-            | Call.Tag condition tagCallInfo -> Some tagCallInfo
+            | Call.Tag condition tagCallInfo -> Tracer.ping(); Some tagCallInfo
             | _ -> None
     [<RequireQualifiedAccess>]
     module Let =
@@ -228,7 +256,7 @@ module internal rec AST =
         /// <returns><c>unit</c></returns>
         let (|Element|_|) =
             function
-            | Let.Ident(Ident.StartsWith "element") -> Some()
+            | Let.Ident(Ident.StartsWith "element") -> Tracer.ping(); Some()
             | _ -> None
         /// <summary>
         /// Pattern matches <c>let</c> bindings for Tags with children
@@ -237,6 +265,7 @@ module internal rec AST =
         let (|TagWithChildren|_|) =
             function
             | Let.Value(Tag.WithChildren(tagName, callInfo, range)) ->
+                Tracer.ping()
                 TagInfo.WithChildren(tagName, callInfo, range) |> Some
             | _ -> None
         /// <summary>
@@ -246,6 +275,7 @@ module internal rec AST =
         let (|TagNoChildrenWithProps|_|) =
             function
             | Let(_, Tag.NoChildren(tagName, range), Sequential exprs) ->
+                Tracer.ping()
                 TagInfo.NoChildren(tagName, exprs, range) |> Some
             | _ -> None
     /// <summary>
@@ -255,12 +285,17 @@ module internal rec AST =
     let (|CallTagNoChildrenWithHandler|_|) (expr: Expr) =
         match expr with
         | Call(Import.Info(ImportInfo.StartsWith "HtmlElementExtensions_"), CallInfo.GetArgs(args :: _), _, range) ->
+            Tracer.ping($"Meets Condition 1: Call(Import.Info(ImportInfo.StartsWith 'HtmlElementExtensions_'), CallInfo.GetArgs(args :: _), _, range)")
             (args, range)
             |> function
-                | Tag.NoChildren(tagName, _), range -> TagInfo.NoChildren(tagName, [ expr ], range) |> Some
+                | Tag.NoChildren(tagName, _), range ->
+                    Tracer.ping("Condition 2 Tag.NoChildren(tagName, _), range ")
+                    TagInfo.NoChildren(tagName, [ expr ], range) |> Some
                 | Let.TagNoChildrenWithProps(NoChildren(tagName, props, _)), range ->
+                    Tracer.ping("Condition 2 Let.TagNoChildrenWithProps(NoChildren(tagName, props, _)), range")
                     TagInfo.NoChildren(tagName, expr :: props, range) |> Some
                 | CallTagNoChildrenWithHandler(NoChildren(tagName, props, _)), range ->
+                    Tracer.ping("Condition 2 CallTagNoChildrenWithHandler(NoChildren(tagName, props, _)), range")
                     TagInfo.NoChildren(tagName, expr :: props, range) |> Some
                 | _ -> None
         | _ -> None
@@ -270,7 +305,7 @@ module internal rec AST =
     /// <returns><c>TagInfo.NoChildren</c></returns>
     let (|LetTagNoChildrenNoProps|_|) =
         function
-        | Let.Value(Tag.NoChildren(tagName, range)) -> TagInfo.NoChildren(tagName, [], range) |> Some
+        | Let.Value(Tag.NoChildren(tagName, range)) -> Tracer.ping(); TagInfo.NoChildren(tagName, [], range) |> Some
         | _ -> None
     /// <summary>
     /// Pattern matches expressions that are text in isolation (no siblings)
@@ -278,26 +313,29 @@ module internal rec AST =
     /// <returns><c>Expr</c> of text</returns>
     let (|TextNoSiblings|_|) =
         function
-        | Lambda(Ident.StartsWith "cont", TypeCast(textBody, Unit), None) -> Some textBody
+        | Lambda(Ident.StartsWith "cont", TypeCast(textBody, Unit), None) -> Tracer.ping(); Some textBody
         | _ -> None
 
     let private (|EventHandler|_|) callInfo =
         match callInfo with
-        | CallInfo.GetArgs [ _; Value(StringConstant eventName, _); handler ] -> Some(eventName, handler)
+        | CallInfo.GetArgs [ _; Value(StringConstant eventName, _); handler ] -> Tracer.ping(); Some(eventName, handler)
         | _ -> None
     [<AutoOpen>]
     module Attributes =
         let (|Extension|_|) =
             function
-            | "on", EventHandler(eventName, handler), restResults -> ("on:" + eventName, handler) :: restResults |> Some
+            | "on", EventHandler(eventName, handler), restResults -> Tracer.ping("on"); ("on:" + eventName, handler) :: restResults |> Some
             | "bool", EventHandler(eventName, handler), restResults ->
+                Tracer.ping("bool")
                 ("bool:" + eventName, handler) :: restResults |> Some
             | "data", EventHandler(eventName, handler), restResults ->
+                Tracer.ping("data")
                 ("data-" + eventName, handler) :: restResults |> Some
-            | "attr", EventHandler(eventName, handler), restResults -> (eventName, handler) :: restResults |> Some
-            | "ref", CallInfo.GetArgs [ _; identExpr ], restResults -> ("ref", identExpr) :: restResults |> Some
-            | "style'", CallInfo.GetArgs [ _; identExpr ], restResults -> ("style", identExpr) :: restResults |> Some
+            | "attr", EventHandler(eventName, handler), restResults -> Tracer.ping("attr"); (eventName, handler) :: restResults |> Some
+            | "ref", CallInfo.GetArgs [ _; identExpr ], restResults -> Tracer.ping("ref"); ("ref", identExpr) :: restResults |> Some
+            | "style'", CallInfo.GetArgs [ _; identExpr ], restResults -> Tracer.ping("style"); ("style", identExpr) :: restResults |> Some
             | "classList", CallInfo.GetArgs [ _; identExpr ], restResults ->
+                Tracer.ping("classList")
                 ("classList", identExpr) :: restResults |> Some
             | _ -> None
         let rec collectAttributes (tracer: Expr list Tracer) =
@@ -305,15 +343,19 @@ module internal rec AST =
             match exprs with
             | [] -> []
             | Sequential expressions :: rest ->
+                Tracer.ping("| [] -> [] | Sequential expressions :: rest")
                 (Tracer.map tracer >> collectAttributes) rest
                 @ (Tracer.map tracer >> collectAttributes) expressions
             | Call(Import.Info importInfo, callInfo, _, _) :: rest ->
+                Tracer.ping("Condition 1: Call(Import.Info importInfo, callInfo, _, _) :: rest")
                 let restResults = (Tracer.map tracer >> collectAttributes) rest
                 match importInfo.Kind with
                 | ImportKind.MemberImport(MemberRef(EntityRef.StartsWith "Oxpecker.Solid", memberRefInfo)) ->
+                    Tracer.ping $"Condition 2: ImportKind.MemberImport(MemberRef(EntityRef.StartsWith 'Oxpecker.Solid', memberRefInfo))"
                     match memberRefInfo.CompiledName, callInfo, restResults with
-                    | Extension propList -> propList
+                    | Extension propList -> Tracer.ping($"Condition 3: Extension propList "); propList
                     | _ ->
+                        Tracer.ping($"Condition 3: _")
                         let setterIndex = memberRefInfo.CompiledName.IndexOf("set_")
                         if setterIndex >= 0 then
                             let propName =
@@ -327,124 +369,163 @@ module internal rec AST =
                                        DeclaredType({
                                                         FullName = "Oxpecker.Solid.Builder.HtmlElement"
                                                     },
-                                                    _)) -> (propName, transform expr) :: restResults
+                                                    _)) ->
+                                Tracer.ping $"Condition 4: TypeCast(expr, DeclaredType({{ FullName = 'Oxpecker.Solid.Builder.HtmlElement' }},_))"
+                                (propName, transform expr) :: restResults
                             | Delegate(args, expr, name, tags) ->
+                                Tracer.ping($"Condition 4: Delegate(args, expr, name, tags)")
                                 (propName, Delegate(args, transform expr, name, tags)) :: restResults
-                            | _ -> (propName, propValue) :: restResults
+                            | _ -> Tracer.ping($"Condition 4: _"); (propName, propValue) :: restResults
                         else
+                            Tracer.ping($"Setter index was >= 0")
                             restResults
-                | _ -> restResults
+                | _ -> Tracer.ping($"Condition 2: _"); restResults
             | Set(IdentExpr(Ident.StartsWith "returnVal"), SetKind.FieldSet name, _, handler, _) :: rest ->
+                Tracer.ping($"Condition 1: Set(IdentExpr(Ident.StartsWith \"returnVal\"), SetKind.FieldSet name, _, handler, _) :: rest")
                 let propName =
                     match name with
                     | name when name.EndsWith("'") -> name.Substring(0, name.Length - 1) // like class' or type'
                     | name -> name
                 (propName, handler) :: (Tracer.map tracer >> collectAttributes) rest
-            | _ :: rest -> (Tracer.map tracer >> collectAttributes) rest
+            | _ :: rest -> Tracer.ping($"Condition 1: _ :: rest"); (Tracer.map tracer >> collectAttributes) rest
 
         let getAttributes currentList (tracer: Expr Tracer) : Props =
             tracer.ping()
             let expr = tracer.Value
             match expr with
             | Let(Ident.StartsWith "returnVal", _, Sequential exprs) ->
+                Tracer.ping("Let(Ident.StartsWith \"returnVal\", _, Sequential exprs)")
                 (Tracer.map(tracer.trace()) >> collectAttributes) exprs @ currentList
             | CallTagNoChildrenWithHandler(NoChildren(_, props, _)) ->
+                Tracer.ping("CallTagNoChildrenWithHandler(NoChildren(_, props, _))")
                 (Tracer.map(tracer.trace()) >> collectAttributes) props @ currentList
-            | _ -> currentList
+            | _ -> Tracer.ping("_"); currentList
     [<AutoOpen>]
     module Children =
         let getChildren currentList (tracer: Expr Tracer) : Expr list =
             let expr = tracer.trace().Value
             match expr with
             | Let.TagWithChildren tagInfo ->
+                Tracer.ping("Let.TagWithChildren tagInfo")
                 let newExpr = transformTagInfo(tagInfo |> Tracer.create)
                 newExpr :: currentList
             | Let.Element & Let.Value(Let.TagNoChildrenWithProps tagInfo) ->
+                Tracer.ping("Let.Element & Let.Value(Let.TagNoChildrenWithProps tagInfo)")
                 let newExpr = transformTagInfo(tagInfo |> Tracer.create)
                 newExpr :: currentList
             | Let.Element & LetTagNoChildrenNoProps tagInfo ->
+                Tracer.ping("Let.Element & LetTagNoChildrenNoProps tagInfo")
                 let newExpr = transformTagInfo(tagInfo |> Tracer.create)
                 newExpr :: currentList
             | Let.Element & Let.Value(CallTagNoChildrenWithHandler tagInfo) ->
+                Tracer.ping("Let.Element & Let.Value(CallTagNoChildrenWithHandler tagInfo)")
                 let newExpr = transformTagInfo(tagInfo |> Tracer.create)
                 newExpr :: currentList
             | Let.Element & Let.Value next ->
+                Tracer.ping("Let.Element & Let.Value next")
                 let newExpr = transform next
                 newExpr :: currentList
             // Lambda with two arguments returning element
             | Lambda(Ident.StartsWith "cont", TypeCast(Lambda(item, Lambda(index, next, _), _), _), _) ->
+                Tracer.ping("Lambda(Ident.StartsWith \"cont\", TypeCast(Lambda(item, Lambda(index, next, _), _), _), _)")
                 Delegate([ item; index ], transform next, None, []) :: currentList
-            | TextNoSiblings body -> body :: currentList
+            | TextNoSiblings body ->
+                Tracer.ping "TextNoSiblings body"
+                body :: currentList
             // text with solid signals inside
-            | Let(Ident.StartsWith "text", body, TextNoSiblings _) -> body :: currentList
+            | Let(Ident.StartsWith "text", body, TextNoSiblings _) ->
+                Tracer.ping "Let(Ident.StartsWith \"text\", body, TextNoSiblings _)"
+                body :: currentList
             // text then tag
             | Let(Ident.StartsWith "second",
                   next,
                   Lambda(Ident.StartsWith "builder", Sequential(TypeCast(textBody, Unit) :: _), _)) ->
+                Tracer.ping "Let(Ident.StartsWith \"second\", next, Lambda(Ident.StartsWith \"builder\", Sequential(TypeCast(textBody, Unit) :: _), _))"
                 getChildren (textBody :: currentList) (Tracer.map tracer next)
             // parameter then another parameter
             | CurriedApply(Lambda(Ident.StartsWith "cont", TypeCast(lastParameter, Unit), Some(StartsWith "second")),
                            _,
                            _,
-                           _) -> lastParameter :: currentList
+                           _) ->
+                Tracer.ping "CurriedApply(Lambda(Ident.StartsWith \"cont\", TypeCast(lastParameter, Unit), Some(StartsWith \"second\")), _, _, _)"
+                lastParameter :: currentList
             | CurriedApply(Lambda(Ident.StartsWith "builder", Sequential [ TypeCast(middleParameter, Unit); next ], _),
                            _,
                            _,
                            _)
             | Lambda(Ident.StartsWith "builder", Sequential [ TypeCast(middleParameter, Unit); next ], _) ->
+                Tracer.ping "| CurriedApply(Lambda(Ident.StartsWith \"builder\", Sequential [ TypeCast(middleParameter, Unit); next ], _), _, _, _) | Lambda(Ident.StartsWith \"builder\", Sequential [ TypeCast(middleParameter, Unit); next ], _)"
                 getChildren (middleParameter :: currentList) (Tracer.map tracer next)
             // tag then text
             | Let(Ident.StartsWith "first",
                   next1,
                   Lambda(Ident.StartsWith "builder", Sequential [ CurriedApply _; next2 ], _)) ->
+                Tracer.ping "Let(Ident.StartsWith \"first\", next1, Lambda(Ident.StartsWith \"builder\", Sequential [ CurriedApply _; next2 ], _))"
                 let next2Children = getChildren [] (Tracer.map tracer next2)
                 let next1Children = getChildren [] (Tracer.map tracer next1)
                 next2Children @ next1Children @ currentList
             | Let(Ident.StartsWith "first", Let.Value expr, Let(Ident.StartsWith "second", next, _))
             | Let(Ident.StartsWith "first", expr, Let(Ident.StartsWith "second", next, _)) ->
+                Tracer.ping "Condition 1: | Let(Ident.StartsWith \"first\", Let.Value expr, Let(Ident.StartsWith \"second\", next, _)) | Let(Ident.StartsWith \"first\", expr, Let(Ident.StartsWith \"second\", next, _))"
                 match expr with
                 | Let.TagNoChildrenWithProps tagInfo ->
+                    Tracer.ping("Condition 2: Let.TagNoChildrenWithProps tagInfo")
                     let newExpr = transformTagInfo(tagInfo |> Tracer.create)
                     getChildren (newExpr :: currentList) (Tracer.map tracer next)
                 | Tag.NoChildren(tagName, range) ->
+                    Tracer.ping("Condition 2: Tag.NoChildren(tagName, range) ")
                     let newExpr =
                         transformTagInfo(TagInfo.NoChildren(tagName, [], range) |> Tracer.create)
                     getChildren (newExpr :: currentList) (Tracer.map tracer next)
                 | Tag.WithChildren callInfo ->
+                    Tracer.ping("Condition 2: Tag.WithChildren callInfo")
                     let newExpr = transformTagInfo(TagInfo.WithChildren callInfo |> Tracer.create)
                     getChildren (newExpr :: currentList) (Tracer.map tracer next)
                 | expr ->
+                    Tracer.ping("Condition 2: expr")
                     let newExpr = transform expr
                     getChildren (newExpr :: currentList) (Tracer.map tracer next)
             | IfThenElse(guardExpr, thenExpr, elseExpr, range) ->
+                Tracer.ping("IfThenElse(guardExpr, thenExpr, elseExpr, range)")
                 IfThenElse(guardExpr, transform thenExpr, transform elseExpr, range)
                 :: currentList
             | DecisionTree(decisionTree, targets) ->
+                Tracer.ping("DecisionTree(decisionTree, targets)")
                 DecisionTree(decisionTree, targets |> List.map(fun (target, expr) -> target, transform expr))
                 :: currentList
             // router cases
             | Call(Get(IdentExpr _, FieldGet _, Any, _), { Args = args }, _, _) ->
+                Tracer.ping("Condition 1: Call(Get(IdentExpr _, FieldGet _, Any, _), { Args = args }, _, _)")
                 match args with
                 | [ Call(Import(ImportInfo.Equals "uncurry2", Any, None), { Args = [ Lambda(_, body, _) ] }, _, _) ] ->
+                    Tracer.ping("Condition 2: [ Call(Import(ImportInfo.Equals \"uncurry2\", Any, None), { Args = [ Lambda(_, body, _) ] }, _, _) ]")
                     getChildren currentList (Tracer.map tracer body)
                 | [ Call.ImportTag(imp, _) ] ->
+                    Tracer.ping("Condition 2: [ Call.ImportTag(imp, _) ]")
                     let newExpr =
                         transformTagInfo(TagInfo.NoChildren(LibraryImport imp, [], None) |> Tracer.create)
                     newExpr :: currentList
                 | [ Let(_, Call.ImportTag(imp, _), Sequential exprs) ] ->
+                    Tracer.ping("Condition 2: [ Let(_, Call.ImportTag(imp, _), Sequential exprs) ]")
                     let newExpr =
                         transformTagInfo(TagInfo.NoChildren(LibraryImport imp, exprs, None) |> Tracer.create)
                     newExpr :: currentList
                 | [ Let(_, Let(_, Call.ImportTag(imp, _), Sequential exprs), Tag.WithChildren(_, callInfo, _)) ] ->
+                    Tracer.ping("Condition 2: [ Let(_, Let(_, Call.ImportTag(imp, _), Sequential exprs), Tag.WithChildren(_, callInfo, _)) ]")
                     let newExpr =
                         transformTagInfo(TagInfo.Combined(LibraryImport imp, exprs, callInfo, None) |> Tracer.create)
                     newExpr :: currentList
                 | [ next1; next2 ] ->
+                    Tracer.ping("Condition 2: [ next1; next2 ]")
                     let next2Children = getChildren [] (Tracer.map tracer next2)
                     let next1Children = getChildren [] (Tracer.map tracer next1)
                     next2Children @ next1Children @ currentList
-                | [ expr ] -> expr :: currentList
-                | _ -> currentList
+                | [ expr ] ->
+                    Tracer.ping("Condition 2: [ expr ]")
+                    expr :: currentList
+                | _ ->
+                    Tracer.ping("Condition 2: _")
+                    currentList
             | Let.Ident {
                             Name = name
                             Range = range
@@ -454,6 +535,7 @@ module internal rec AST =
                  || (name.StartsWith("element") && fullName.StartsWith("Oxpecker.Solid")))
                 |> not
                 ->
+                Tracer.ping "Let.Ident { Name = name; Range = range; Type = DeclaredType({ FullName = fullName }, []) } when ((name.StartsWith(\"returnVal\") && fullName.StartsWith(\"Oxpecker.Solid\")) || (name.StartsWith(\"element\") && fullName.StartsWith(\"Oxpecker.Solid\"))) |> not"
                 match range with
                 | Some range ->
                     failwith $"`let` binding inside HTML CE can't be converted to JSX:line {range.start.line}"
@@ -493,11 +575,13 @@ module internal rec AST =
 
 
     let convertExprListToExpr (exprs: Expr list) =
+        Tracer.ping()
         (Baked.emptyList, exprs)
         ||> List.fold(fun acc prop ->
             Value(kind = NewList(headAndTail = Some(prop, acc), typ = Baked.listItemType), range = None))
 
     let wrapChildrenExpression childrenExpression =
+        Tracer.ping()
         Value(
             kind =
                 NewTuple(
@@ -518,16 +602,19 @@ module internal rec AST =
         let tagName, props, children, range =
             match tagInfo with
             | WithChildren(tagName, callInfo, range) ->
+                Tracer.ping("tagInfo - WithChildren(tagName, callInfo, range)")
                 let props =
                     callInfo.Args |> List.map(Tracer.map tracer) |> List.fold getAttributes []
                 let childrenList =
                     callInfo.Args |> List.map(Tracer.map tracer) |> List.fold getChildren []
                 tagName, props, childrenList, range
             | NoChildren(tagName, propList, range) ->
+                Tracer.ping("tagInfo - NoChildren(tagName, propLiust, range")
                 let props = propList |> Tracer.map tracer |> collectAttributes
                 let childrenList = []
                 tagName, props, childrenList, range
             | Combined(tagName, propList, callInfo, range) ->
+                Tracer.ping("tagInfo - Combined(tagName, propList, callInfo, range")
                 let props = propList |> Tracer.map tracer |> collectAttributes
                 let childrenList =
                     callInfo.Args |> List.map(Tracer.map tracer) |> List.fold getChildren []
@@ -555,8 +642,12 @@ module internal rec AST =
         let propsExpr = convertExprListToExpr finalList
         let tag =
             match tagName with
-            | AutoImport tagName -> Value(StringConstant tagName, None)
-            | LibraryImport imp -> imp
+            | AutoImport tagName ->
+                Tracer.ping("tag - AutoImport")
+                Value(StringConstant tagName, None)
+            | LibraryImport imp ->
+                Tracer.ping("tag - LibraryImport")
+                imp
         tracer.ping("Finalised")
         Call(
             callee = Baked.importJsxCreate,
@@ -578,35 +669,38 @@ module internal rec AST =
         match expr with
         | Let.TagNoChildrenWithProps tagCall
         | Let.Element & Let(_, Let.TagNoChildrenWithProps tagCall, _) ->
-            transformTagInfo(tagCall |> Tracer.create |> _.trace())
+            transformTagInfo(tagCall |> Tracer.create |> _.trace("| Let.TagNoChildrenWithProps tagCall | Let.Element & Let(_, Let.TagNoChildrenWithProps tagCall, _)"))
         | Tag.NoChildren(tagName, range) ->
-            transformTagInfo(TagInfo.NoChildren(tagName, [], range) |> Tracer.create |> _.trace())
-        | CallTagNoChildrenWithHandler tagCall -> transformTagInfo(tagCall |> Tracer.create |> _.trace())
-        | LetTagNoChildrenNoProps tagCall -> transformTagInfo(tagCall |> Tracer.create |> _.trace())
-        | Tag.WithChildren callInfo -> transformTagInfo(TagInfo.WithChildren callInfo |> Tracer.create |> _.trace())
-        | Let.TagWithChildren tagCall -> transformTagInfo(tagCall |> Tracer.create |> _.trace())
+            transformTagInfo(TagInfo.NoChildren(tagName, [], range) |> Tracer.create |> _.trace("Tag.NoChildren(tagName, range)"))
+        | CallTagNoChildrenWithHandler tagCall -> transformTagInfo(tagCall |> Tracer.create |> _.trace("CallTagNoChildrenWithHandler tagCall"))
+        | LetTagNoChildrenNoProps tagCall -> transformTagInfo(tagCall |> Tracer.create |> _.trace("LetTagNoChildrenNoProps tagCall"))
+        | Tag.WithChildren callInfo -> transformTagInfo(TagInfo.WithChildren callInfo |> Tracer.create |> _.trace("Tag.WithChildren callInfo"))
+        | Let.TagWithChildren tagCall -> transformTagInfo(tagCall |> Tracer.create |> _.trace("Let.TagWithChildren tagCall"))
         | Call.ImportTag(imp, range) ->
-            transformTagInfo(TagInfo.NoChildren(LibraryImport imp, [], range) |> Tracer.create |> _.trace())
+            transformTagInfo(TagInfo.NoChildren(LibraryImport imp, [], range) |> Tracer.create |> _.trace("Call.ImportTag(imp,range)"))
         | Let(_, Call.ImportTag(imp, range), Tag.WithChildren(_, callInfo, _)) ->
             transformTagInfo(
                 TagInfo.WithChildren(LibraryImport imp, callInfo, range)
                 |> Tracer.create
-                |> _.trace()
+                |> _.trace("Let(_, Call.ImportTag(imp, range), Tag.WithChildren(_, callInfo, _))")
             )
         | Let(_, Call.ImportTag(imp, range), Sequential exprs) ->
             transformTagInfo(
                 TagInfo.NoChildren(LibraryImport imp, exprs, range)
                 |> Tracer.create
-                |> _.trace()
+                |> _.trace("Let(_, Call.ImportTag(imp, range), Sequential exprs)")
             )
         | Let(_, Let(_, Call.ImportTag(imp, range), Sequential exprs), Tag.WithChildren(_, callInfo, _)) ->
             transformTagInfo(
                 TagInfo.Combined(LibraryImport imp, exprs, callInfo, range)
                 |> Tracer.create
-                |> _.trace()
+                |> _.trace("Let(_, Let(_, Call.ImportTag(imp, range), Sequential exprs), Tag.WithChildren(_, callInfo, _))")
             )
-        | Let(name, value, expr) -> Let(name, value, (transform expr))
+        | Let(name, value, expr) ->
+            Tracer.ping("Let(name, value, expr)")
+            Let(name, value, (transform expr))
         | Sequential expressions ->
+            Tracer.ping("Sequential expressions")
             // transform only the last expression
             Sequential(
                 expressions
@@ -614,19 +708,27 @@ module internal rec AST =
             )
         // transform children passed to component function call
         | Call(callee, callInfo, typ, range) ->
-            tracer.ping("Transform children passed to component function call")
+            Tracer.ping "Call(callee, callInfo, typ, range)"
             let newCallInfo = {
                 callInfo with
                     Args = callInfo.Args |> List.map transform
             }
             Call(callee, newCallInfo, typ, range)
-        | TextNoSiblings body -> body
+        | TextNoSiblings body ->
+            Tracer.ping "TextNoSiblings body"
+            body
         | IfThenElse(guardExpr, thenExpr, elseExpr, range) ->
+            Tracer.ping "IfThenElse(guardExpr, thenExpr, elseExpr, range)"
             IfThenElse(guardExpr, transform thenExpr, transform elseExpr, range)
         | DecisionTree(decisionTree, targets) ->
+            Tracer.ping "DecisionTree(decisionTree, targets)"
             DecisionTree(decisionTree, targets |> List.map(fun (target, expr) -> target, transform expr))
-        | TypeCast(expr, DeclaredType _) -> transform expr
-        | _ -> expr
+        | TypeCast(expr, DeclaredType _) ->
+            Tracer.ping "TypeCast(expr, DeclaredType _)"
+            transform expr
+        | _ ->
+            Tracer.ping "_"
+            expr
     let transform (expr: Expr) = expr |> Tracer.create |> transform'
     let transformException (pluginHelper: PluginHelper) (range: SourceLocation option) =
         let childrenExpression =
@@ -667,6 +769,9 @@ type SolidComponentAttribute() =
 
     override this.Transform(pluginHelper: PluginHelper, file: File, memberDecl: MemberDecl) =
         PluginConfiguration.configure pluginHelper
+        use fs = new IO.FileStream("PluginOutput.txt", IO.FileMode.Create)
+        use sw = new IO.StreamWriter(fs)
+        Console.SetOut sw
         if PluginConfiguration.Verbose() then
             enableTrace()
         // Console.WriteLine("!Start! MemberDecl")
@@ -676,6 +781,9 @@ type SolidComponentAttribute() =
             match memberDecl.Body with
             | Extended(Throw _, range) -> AST.transformException pluginHelper range
             | _ -> AST.transform memberDecl.Body
+        let standardOutput = new IO.StreamWriter(Console.OpenStandardOutput())
+        standardOutput.AutoFlush <- true
+        Console.SetOut standardOutput
         { memberDecl with Body = newBody }
 
     override _.TransformCall(_: PluginHelper, _: MemberFunctionOrValue, expr: Expr) : Expr = expr

--- a/src/Oxpecker.Solid.FablePlugin/Library.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Library.fs
@@ -209,6 +209,9 @@ module internal rec AST =
                 | Tag.NoChildren(tagName, _), range ->
                     Tracer.ping("Condition 2 Tag.NoChildren(tagName, _), range ")
                     TagInfo.NoChildren(tagName, [ expr ], range) |> Some
+                | Call.ImportTag(imp, _), range ->
+                    Tracer.ping("Condition 2 Call.ImportTag(imp, _), range")
+                    TagInfo.NoChildren(LibraryImport imp, [ expr ], range) |> Some
                 | Let.TagNoChildrenWithProps(NoChildren(tagName, props, _)), range ->
                     Tracer.ping("Condition 2 Let.TagNoChildrenWithProps(NoChildren(tagName, props, _)), range")
                     TagInfo.NoChildren(tagName, expr :: props, range) |> Some
@@ -263,6 +266,8 @@ module internal rec AST =
             | "attr", EventHandler(eventName, handler), restResults ->
                 Tracer.ping("attr")
                 (eventName, handler) :: restResults |> Some
+            | "spread", CallInfo.GetArgs [ _; identExpr ], restResults ->
+                ("__SPREAD_PROPERTY__", identExpr) :: restResults |> Some
             | "ref", CallInfo.GetArgs [ _; identExpr ], restResults ->
                 Tracer.ping("ref")
                 ("ref", identExpr) :: restResults |> Some

--- a/src/Oxpecker.Solid.FablePlugin/Library.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Library.fs
@@ -266,8 +266,6 @@ module internal rec AST =
             | "attr", EventHandler(eventName, handler), restResults ->
                 Tracer.ping("attr")
                 (eventName, handler) :: restResults |> Some
-            | "spread", CallInfo.GetArgs [ _; identExpr ], restResults ->
-                ("__SPREAD_PROPERTY__", identExpr) :: restResults |> Some
             | "ref", CallInfo.GetArgs [ _; identExpr ], restResults ->
                 Tracer.ping("ref")
                 ("ref", identExpr) :: restResults |> Some

--- a/src/Oxpecker.Solid.FablePlugin/Library.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Library.fs
@@ -576,10 +576,12 @@ module internal rec AST =
                     callInfo.Args |> List.map(Tracer.bind tracer) |> List.fold getAttributes []
                 let childrenList =
                     callInfo.Args |> List.map(Tracer.bind tracer) |> List.fold getChildren []
-                match props |> List.tryFind (fun (propName,_) -> propName = "__LIFT_TAG__") with
-                | Some (_, imp) ->
-                    LibraryImport imp, props |> List.filter(fun (propName, _) -> propName <> "__LIFT_TAG__")
-                    , childrenList, range
+                match props |> List.tryFind(fun (propName, _) -> propName = "__LIFT_TAG__") with
+                | Some(_, imp) ->
+                    LibraryImport imp,
+                    props |> List.filter(fun (propName, _) -> propName <> "__LIFT_TAG__"),
+                    childrenList,
+                    range
                 | None -> tagName, props, childrenList, range
             | NoChildren(tagName, propList, range) ->
                 Tracer.ping("tagInfo - NoChildren(tagName, propLiust, range")

--- a/src/Oxpecker.Solid.FablePlugin/Library.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Library.fs
@@ -470,8 +470,11 @@ module internal rec AST =
             | Let.Ident {
                             Name = name
                             Range = range
-                            Type = DeclaredType(EntityRef.StartsWith "Oxpecker.Solid", [])
-                        } when not(name.StartsWith("returnVal") || name.StartsWith("element")) ->
+                            Type = DeclaredType({ FullName = fullName }, [])
+                        }
+                when ((name.StartsWith("returnVal") && fullName.StartsWith("Oxpecker.Solid"))
+                 || (name.StartsWith("element") && fullName.StartsWith("Oxpecker.Solid")))
+                |> not ->
                 match range with
                 | Some range ->
                     failwith $"`let` binding inside HTML CE can't be converted to JSX:line {range.start.line}"

--- a/src/Oxpecker.Solid.FablePlugin/Library.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Library.fs
@@ -214,6 +214,9 @@ module internal rec AST =
                 | Let.TagNoChildrenWithProps(NoChildren(tagName, props, _)), range ->
                     Tracer.ping("Condition 2 Let.TagNoChildrenWithProps(NoChildren(tagName, props, _)), range")
                     TagInfo.NoChildren(tagName, expr :: props, range) |> Some
+                | Let(_, Call.ImportTag(imp, _), Sequential exprs), _ ->
+                    Tracer.ping("Condition 2 Let(_,Call.ImportTag(imp, _), Sequential exprs), _")
+                    TagInfo.NoChildren(LibraryImport imp, expr :: exprs, range) |> Some
                 | CallTagNoChildrenWithHandler(NoChildren(tagName, props, _)), range ->
                     Tracer.ping("Condition 2 CallTagNoChildrenWithHandler(NoChildren(tagName, props, _)), range")
                     TagInfo.NoChildren(tagName, expr :: props, range) |> Some

--- a/src/Oxpecker.Solid.FablePlugin/Oxpecker.Solid.FablePlugin.fsproj
+++ b/src/Oxpecker.Solid.FablePlugin/Oxpecker.Solid.FablePlugin.fsproj
@@ -30,6 +30,8 @@
     <ItemGroup>
         <None Include="..\..\images\oxpecker-128.png" Pack="true" PackagePath="\" />
         <None Include="README.md" Pack="true" PackagePath="\" />
+        <Compile Include="Types.fs" />
+        <Compile Include="PrettyPrint.fs" />
         <Compile Include="Library.fs" />
     </ItemGroup>
 

--- a/src/Oxpecker.Solid.FablePlugin/PrettyPrint.fs
+++ b/src/Oxpecker.Solid.FablePlugin/PrettyPrint.fs
@@ -89,7 +89,7 @@ module private rec PrettyPrint =
         override this.Write(writer, value, options) =
             if simplify() then
                 nameof EntityPath |> wrapUnionType |> writer.WriteStringValue
-            elif  canWrite writer then
+            elif canWrite writer then
                 let prefix postfix = $"{nameof EntityPath}.{postfix}"
                 writer.WriteStartObject()
                 match value with
@@ -971,4 +971,3 @@ module private rec PrettyPrint =
 type PrettyPrinter =
     static member print(value: 'T) : string =
         JsonSerializer.Serialize(value, PrettyPrint.options)
-

--- a/src/Oxpecker.Solid.FablePlugin/PrettyPrint.fs
+++ b/src/Oxpecker.Solid.FablePlugin/PrettyPrint.fs
@@ -1,4 +1,4 @@
-﻿namespace rec Fable.Plugin.Tracer
+﻿namespace rec Oxpecker.Solid
 
 open System
 open System.Runtime.InteropServices

--- a/src/Oxpecker.Solid.FablePlugin/PrettyPrint.fs
+++ b/src/Oxpecker.Solid.FablePlugin/PrettyPrint.fs
@@ -1,0 +1,561 @@
+﻿namespace Oxpecker.Solid.FablePlugin
+
+open System
+open Fable.AST
+open Fable.AST.Fable
+open Types
+open System.Text.Json
+
+module internal rec PrettyPrint =
+    type EntityPathConverter() =
+        inherit Serialization.JsonConverter<EntityPath>()
+        override this.CanConvert typ = typ = typeof<EntityPath>
+        override this.Read(_,_,_) = unbox null
+        override this.Write( writer, value, options ) =
+            let prefix postfix = $"{nameof EntityPath}.{postfix}"
+            match value with
+            | SourcePath s -> writer.WriteString (prefix (nameof SourcePath), s)
+            | AssemblyPath s -> writer.WriteString (prefix (nameof AssemblyPath), s)
+            | CoreAssemblyName s -> writer.WriteString (prefix (nameof CoreAssemblyName), s)
+            | PrecompiledLib(sourcePath, assemblyPath) -> writer.WriteString (prefix (nameof PrecompiledLib), JsonSerializer.Serialize {|sourcePath = sourcePath; assemblyPath = assemblyPath|})
+    type MemberRefConverter() =
+        inherit Serialization.JsonConverter<MemberRef>()
+        override this.CanConvert typ = typ = typeof<MemberRef>
+        override this.Read(_,_,_) = unbox null
+        override this.Write( writer, value, options) =
+            let prefix postfix = $"{nameof MemberRef}.{postfix}"
+            match value with
+            | MemberRef(declaringEntity, info) ->
+                let inp = {|declaringEntity=declaringEntity;info=info|}
+                writer.WritePropertyName (prefix (nameof MemberRef))
+                JsonSerializer.Serialize(writer, inp, inp.GetType(), options)
+            | GeneratedMemberRef generatedMember ->
+                nameof GeneratedMemberRef |> prefix |> writer.WritePropertyName
+                JsonSerializer.Serialize(writer, generatedMember, generatedMember.GetType(), options)
+    type GeneratedMemberConverter() =
+        inherit Serialization.JsonConverter<GeneratedMember>()
+        override this.CanConvert typ = typ = typeof<GeneratedMember>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            let prefix postfix = $"{nameof GeneratedMember}.{postfix}"
+            match value with
+            | GeneratedFunction info ->
+                let object = {|GeneratedFunction=info|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | GeneratedValue info ->
+                let object = {|GeneratedValue=info|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | GeneratedGetter info ->
+                let object = {|GeneratedGetter=info|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | GeneratedSetter info ->
+                let object = {|GeneratedSetter=info|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+    type NumberInfoConverter() =
+        inherit Serialization.JsonConverter<NumberInfo>()
+        override this.CanConvert typ = typ = typeof<NumberInfo>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            let prefix postfix = $"{nameof NumberInfo}.{postfix}"
+            match value with
+            | NumberInfo.Empty -> nameof NumberInfo.Empty |> prefix |> writer.WriteNull
+            | NumberInfo.IsMeasure fullname -> nameof NumberInfo.IsMeasure |> prefix |> fun prop -> writer.WriteString (prop, fullname)
+            | NumberInfo.IsEnum ent ->
+                nameof NumberInfo.IsEnum |> prefix |> writer.WritePropertyName
+                JsonSerializer.Serialize(writer, ent, ent.GetType(), options)
+    type NumberValueConverter() =
+        inherit Serialization.JsonConverter<NumberValue>()
+        override this.CanConvert typ = typ = typeof<NumberValue>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            match value with
+            | NumberValue.Int8 b -> JsonSerializer.Serialize(writer, b, b.GetType(), options)
+            | NumberValue.UInt8 b -> JsonSerializer.Serialize(writer, b, b.GetType(), options)
+            | NumberValue.Int16 s -> JsonSerializer.Serialize(writer, s, s.GetType(), options)
+            | NumberValue.UInt16 s -> JsonSerializer.Serialize(writer, s, s.GetType(), options)
+            | NumberValue.Int32 i -> JsonSerializer.Serialize(writer, i, i.GetType(), options)
+            | NumberValue.UInt32 i -> JsonSerializer.Serialize(writer, i, i.GetType(), options)
+            | NumberValue.Int64 int64 -> JsonSerializer.Serialize(writer, int64, int64.GetType(), options)
+            | NumberValue.UInt64 uInt64 -> JsonSerializer.Serialize(writer, uInt64, uInt64.GetType(), options)
+            | NumberValue.Int128(upper, lower) -> $"{upper}{lower}" |> fun v -> writer.WriteRawValue(v,true)
+            | NumberValue.UInt128(upper, lower) -> $"{upper}{lower}" |> fun v -> writer.WriteRawValue(v,true)
+            | NumberValue.BigInt bigInteger -> JsonSerializer.Serialize(writer, bigInteger, bigInteger.GetType(), options)
+            | NumberValue.NativeInt intPtr -> JsonSerializer.Serialize(writer, intPtr, intPtr.GetType(), options)
+            | NumberValue.UNativeInt uIntPtr -> JsonSerializer.Serialize(writer, uIntPtr, uIntPtr.GetType(), options)
+            | NumberValue.Float16 f -> JsonSerializer.Serialize(writer, f, f.GetType(), options)
+            | NumberValue.Float32 f -> JsonSerializer.Serialize(writer, f, f.GetType(), options)
+            | NumberValue.Float64 f -> JsonSerializer.Serialize(writer, f, f.GetType(), options)
+            | NumberValue.Decimal decimal -> JsonSerializer.Serialize(writer, decimal, decimal.GetType(), options)
+    type ArrayKindConverter() =
+        inherit Serialization.JsonConverter<ArrayKind>()
+        override this.CanConvert typ = typ = typeof<ArrayKind>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            match value with
+            | ResizeArray -> nameof ResizeArray
+            | MutableArray -> nameof MutableArray
+            | ImmutableArray -> nameof ImmutableArray
+            |> fun value -> writer.WriteString (nameof ArrayKind,value)
+    type ConstraintConverter() =
+        inherit Serialization.JsonConverter<Constraint>()
+        override this.CanConvert typ = typ = typeof<Constraint>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            let wrap input = $"\"{input}\""
+            writer.WriteStartObject()
+            match value with
+            | Constraint.HasMember(name, isStatic) ->
+                writer.WritePropertyName $"{nameof Constraint}.{nameof Constraint.HasMember}"
+                let object = {|name=name;isStatic=isStatic|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Constraint.CoercesTo target ->
+                writer.WritePropertyName $"{nameof Constraint}.{nameof Constraint.CoercesTo}"
+                // JsonSerializer.Serialize(writer, target, target.GetType(), options)
+            | Constraint.IsNullable ->
+                let object = wrap $"{nameof Constraint}.{nameof Constraint.IsNullable}"
+                writer.WriteRawValue(object, true)
+            | Constraint.IsValueType ->
+                let object = wrap $"{nameof Constraint}.{nameof Constraint.IsValueType}"
+                writer.WriteRawValue(object, true)
+            | Constraint.IsReferenceType ->
+                let object = wrap $"{nameof Constraint}.{nameof Constraint.IsReferenceType}"
+                writer.WriteRawValue(object, true)
+            | Constraint.HasDefaultConstructor ->
+                let object = wrap $"{nameof Constraint}.{nameof Constraint.HasDefaultConstructor}"
+                writer.WriteRawValue(object, true)
+            | Constraint.HasComparison ->
+                let object = wrap $"{nameof Constraint}.{nameof Constraint.HasComparison}"
+                writer.WriteRawValue(object, true)
+            | Constraint.HasEquality ->
+                let object = wrap $"{nameof Constraint}.{nameof Constraint.HasEquality}"
+                writer.WriteRawValue(object, true)
+            | Constraint.IsUnmanaged ->
+                let object = wrap $"{nameof Constraint}.{nameof Constraint.IsUnmanaged}"
+                writer.WriteRawValue(object, true)
+            | Constraint.IsEnum ->
+                let object = wrap $"{nameof Constraint}.{nameof Constraint.IsEnum}"
+                writer.WriteRawValue(object, true)
+            writer.WriteEndObject()
+    type TypeConverter() =
+        inherit Serialization.JsonConverter<Fable.Type>()
+        override this.CanConvert typ = typ = typeof<Fable.Type>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            let wrap input = $"\"{input}\""
+            let prefix postfix = $"{nameof Fable.Type}.{postfix}"
+            writer.WriteStartObject()
+            match value with
+            | Type.Measure fullname -> writer.WriteString(prefix (nameof Measure), fullname)
+            | Type.MetaType -> let object = (nameof MetaType) |> prefix |> wrap in writer.WriteRawValue(object, true)
+            | Type.Any -> let object = (nameof Any) |> prefix |> wrap in writer.WriteRawValue(object, true)
+            | Type.Unit -> let object = (nameof Unit) |> prefix |> wrap in writer.WriteRawValue(object, true)
+            | Type.Boolean -> let object = (nameof Boolean) |> prefix |> wrap in writer.WriteRawValue(object, true)
+            | Type.Char -> let object = (nameof Char) |> prefix |> wrap in writer.WriteRawValue(object, true)
+            | Type.String -> let object = (nameof String) |> prefix |> wrap in writer.WriteRawValue(object, true)
+            | Type.Regex -> let object = (nameof Regex) |> prefix |> wrap in writer.WriteRawValue(object, true)
+            | Type.Number(kind, info) ->
+                writer.WritePropertyName (prefix (nameof Number))
+                let object = {|kind=kind;info=info|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Type.Option(genericArg, isStruct) ->
+                writer.WritePropertyName (prefix (nameof Option))
+                let object = {|genericArg=genericArg;isStruct=isStruct|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Type.Tuple(genericArgs, isStruct) ->
+                writer.WritePropertyName (prefix (nameof Tuple))
+                let object = {|genericArgs=genericArgs;isStruct=isStruct|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Type.Array(genericArg, kind) ->
+                writer.WritePropertyName (prefix (nameof Array))
+                let object = {|genericArg=genericArg;kind=kind|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Type.List genericArg ->
+                writer.WritePropertyName (prefix (nameof List))
+                let object = {|genericArg=genericArg|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Type.LambdaType(argType, returnType) ->
+                writer.WritePropertyName (prefix (nameof LambdaType))
+                let object = {|argType=argType; returnType=returnType|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Type.DelegateType(argTypes, returnType) ->
+                writer.WritePropertyName (prefix (nameof DelegateType))
+                let object = {|argTypes=argTypes; returnType=returnType|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Type.GenericParam(name, isMeasure, constraints) ->
+                writer.WritePropertyName (prefix (nameof GenericParam))
+                let object = {|name=name;isMeasure=isMeasure;constraints=constraints|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Type.DeclaredType(rref, genericArgs) ->
+                writer.WritePropertyName (prefix (nameof DeclaredType))
+                let object = {|rref=rref;genericArgs=genericArgs|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Type.AnonymousRecordType(fieldNames, genericArgs, isStruct) ->
+                writer.WritePropertyName (prefix (nameof AnonymousRecordType))
+                let object = {|fieldNames=fieldNames;genericArgs=genericArgs;isStruct=isStruct|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            writer.WriteEndObject()
+    type ExprConverter() =
+        inherit Serialization.JsonConverter<Expr>()
+        override this.CanConvert typ = typ = typeof<Expr>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            let prefix postfix = $"{nameof Expr}.{postfix}"
+            let wrap input = $"\"{input}\""
+            writer.WriteStartObject()
+            match value with
+            | IdentExpr ident ->
+                writer.WritePropertyName(prefix(nameof IdentExpr))
+                JsonSerializer.Serialize(writer, ident, ident.GetType(), options)
+            | Value(kind, range) ->
+                writer.WritePropertyName(prefix(nameof Value))
+                let object = {|kind=kind;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Lambda(arg, body, name) ->
+                writer.WritePropertyName(prefix(nameof Lambda))
+                let object = {|arg=arg;body=body;name=name|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Delegate(args, body, name, tags) ->
+                writer.WritePropertyName(prefix(nameof Delegate))
+                let object = {|args=args;body=body;name=name;tags=tags|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | ObjectExpr(members, typ, baseCall) ->
+                writer.WritePropertyName(prefix(nameof ObjectExpr))
+                let object = {|members=members;``type``=typ;baseCall=baseCall|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | TypeCast(expr, typ) ->
+                writer.WritePropertyName(prefix(nameof TypeCast))
+                let object = {|expr=expr;``type``=typ|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Test(expr, kind, range) ->
+                writer.WritePropertyName(prefix(nameof Test))
+                let object = {|expr=expr;kind=kind;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Call(callee, info, typ, range) ->
+                writer.WritePropertyName(prefix(nameof Call))
+                let object = {|callee=callee;info=info;``type``=typ;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | CurriedApply(applied, args, typ, range) ->
+                writer.WritePropertyName(prefix(nameof CurriedApply))
+                let object = {|applied=applied;args=args;``type``=typ;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Operation(kind, tags, typ, range) ->
+                writer.WritePropertyName(prefix(nameof Operation))
+                let object = {|kind=kind;tags=tags;``type``=typ;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Import(info, typ, range) ->
+                writer.WritePropertyName(prefix(nameof Import))
+                let object = {|info=info;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Emit(info, typ, range) ->
+                writer.WritePropertyName(prefix(nameof Emit))
+                let object = {|info=info;``type``=typ;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | DecisionTree(expr, targets) ->
+                writer.WritePropertyName(prefix(nameof DecisionTree))
+                let object = {|expr=expr;targets=targets|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | DecisionTreeSuccess(targetIndex, boundValues, typ) ->
+                writer.WritePropertyName(prefix(nameof DecisionTreeSuccess))
+                let object = {|targetIndex=targetIndex;boundValues=boundValues;``type``=typ|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Let(ident, value, body) ->
+                writer.WritePropertyName(prefix(nameof Let))
+                let object = {|ident=ident;value=value;body=body|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | LetRec(bindings, body) ->
+                writer.WritePropertyName(prefix(nameof LetRec))
+                let object = {|bindings=bindings;body=body|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Get(expr, kind, typ, range) ->
+                writer.WritePropertyName(prefix(nameof Get))
+                let object = {|expr=expr;kind=kind;``type``=typ;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Set(expr, kind, typ, value, range) ->
+                writer.WritePropertyName(prefix(nameof Set))
+                let object = {|expr=expr;kind=kind;``type``=typ;value=value;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Sequential exprs ->
+                writer.WritePropertyName(prefix(nameof Sequential))
+                let object = exprs
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | WhileLoop(guard, body, range) ->
+                writer.WritePropertyName(prefix(nameof WhileLoop))
+                let object = {|guard=guard;body=body;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | ForLoop(ident, start, limit, body, isUp, range) ->
+                writer.WritePropertyName(prefix(nameof ForLoop))
+                let object = {|ident=ident;start=start;limit=limit;body=body;isUp=isUp;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | TryCatch(body, catch, finalizer, range) ->
+                writer.WritePropertyName(prefix(nameof TryCatch))
+                let object = {|body=body;catch=catch;finalizer=finalizer;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | IfThenElse(guardExpr, thenExpr, elseExpr, range) ->
+                writer.WritePropertyName(prefix(nameof IfThenElse))
+                let object = {|guardExpr=guardExpr;thenExpr=thenExpr;elseExpr=elseExpr;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Unresolved(expr, typ, range) ->
+                writer.WritePropertyName(prefix(nameof Unresolved))
+                let object = {|expr=expr;``type``=typ;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Extended(expr, range) ->
+                writer.WritePropertyName(prefix(nameof Extended))
+                let object = {|expr=expr;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            writer.WriteEndObject()
+    type ValueKindConverter() =
+        inherit Serialization.JsonConverter<ValueKind>()
+        override this.CanConvert typ = typ = typeof<ValueKind>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            let prefix postfix = $"{nameof ValueKind}.{postfix}"
+            let wrap input = $"\"{input}\""
+            writer.WriteStartObject()
+            match value with
+            | ThisValue typ ->
+                nameof ThisValue |> prefix |> wrap |> writer.WritePropertyName
+                let object = typ
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | BaseValue(boundIdent, typ) ->
+                nameof BaseValue |> prefix |> wrap |> writer.WritePropertyName
+                let object = {|boundIdent=boundIdent;``type``=typ|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | TypeInfo(typ, tags) ->
+                nameof TypeInfo |> prefix |> wrap |> writer.WritePropertyName
+                let object = {|``type``=typ;tags=tags|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Null typ ->
+                nameof Null |> prefix |> wrap |> writer.WritePropertyName
+                let object = typ
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | UnitConstant ->
+                nameof UnitConstant |> prefix |> wrap |> writer.WritePropertyName
+                let object = ()
+                JsonSerializer.Serialize(writer, object, typeof<unit>, options)
+            | BoolConstant value ->
+                nameof BoolConstant |> prefix |> wrap |> writer.WritePropertyName
+                let object = value
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | CharConstant value ->
+                nameof CharConstant |> prefix |> wrap |> writer.WritePropertyName
+                let object = value
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | StringConstant value ->
+                nameof StringConstant |> prefix |> wrap |> writer.WritePropertyName
+                let object = value
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | StringTemplate(tag, parts, values) ->
+                nameof StringTemplate |> prefix |> wrap |> writer.WritePropertyName
+                let object = {|tag=tag;parts=parts;values=values|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | NumberConstant(value, info) ->
+                nameof NumberConstant |> prefix |> wrap |> writer.WritePropertyName
+                let object = {|value=value;info=info|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | RegexConstant(source, flags) ->
+                nameof RegexConstant |> prefix |> wrap |> writer.WritePropertyName
+                let object = {|source=source;flags=flags|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | NewOption(value, typ, isStruct) ->
+                nameof NewOption |> prefix |> wrap |> writer.WritePropertyName
+                let object = {|value=value;``type``=typ;isStruct=isStruct|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | NewArray(newKind, typ, kind) ->
+                nameof NewArray |> prefix |> wrap |> writer.WritePropertyName
+                let object = {|newKind=newKind;``type``=typ;kind=kind|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | NewList(headAndTail, typ) ->
+                nameof NewList |> prefix |> wrap |> writer.WritePropertyName
+                let object = {|headAndTail=headAndTail;``type``=typ|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | NewTuple(values, isStruct) ->
+                nameof NewTuple |> prefix |> wrap |> writer.WritePropertyName
+                let object = {|values=values;isStruct=isStruct|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | NewRecord(values, rref, genArgs) ->
+                nameof NewRecord |> prefix |> wrap |> writer.WritePropertyName
+                let object = {|values=values;rref=rref;genArgs=genArgs|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | NewAnonymousRecord(values, fieldNames, genArgs, isStruct) ->
+                nameof NewAnonymousRecord |> prefix |> wrap |> writer.WritePropertyName
+                let object = {|values=values;fieldNames=fieldNames;genArgs=genArgs;isStruct=isStruct|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | NewUnion(values, tag, rref, genArgs) ->
+                nameof NewUnion |> prefix |> wrap |> writer.WritePropertyName
+                let object = {|values=values;tag=tag;rref=rref;genArgs=genArgs|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            writer.WriteEndObject()
+    type TagSourceConverter() =
+        inherit Serialization.JsonConverter<TagSource>()
+        override this.CanConvert typ = typ = typeof<TagSource>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            let prefix postfix = $"{nameof TagSource}.{postfix}"
+            writer.WriteStartObject()
+            match value with
+            | AutoImport tagName -> writer.WriteString(prefix (nameof AutoImport), tagName)
+            | LibraryImport imp ->
+                writer.WritePropertyName (prefix (nameof LibraryImport))
+                JsonSerializer.Serialize(writer, imp, typeof<Expr>, options)
+            writer.WriteEndObject()
+    type TagInfoConverter() =
+        inherit Serialization.JsonConverter<TagInfo>()
+        override this.CanConvert typ = typ = typeof<TagInfo>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            let prefix postfix = $"{nameof TagInfo}.{postfix}"
+            writer.WriteStartObject()
+            match value with
+            | WithChildren(tagName, propsAndChildren, range) ->
+                nameof WithChildren |> prefix |> writer.WritePropertyName
+                let object = {|tagName=tagName;propsAndChildren=propsAndChildren;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | NoChildren(tagName, props, range) ->
+                nameof NoChildren |> prefix |> writer.WritePropertyName
+                let object = {|tagName=tagName;props=props;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            | Combined(tagName, props, propsAndChildren, range) ->
+                nameof Combined |> prefix |> writer.WritePropertyName
+                let object = {|tagName=tagName;props=props;propsAndChildren=propsAndChildren;range=range|}
+                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            writer.WriteEndObject()
+    type ImportKindConverter() =
+        inherit Serialization.JsonConverter<ImportKind>()
+        override this.CanConvert typ = typ = typeof<ImportKind>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            ()
+    type DeclarationConverter() =
+        inherit Serialization.JsonConverter<Declaration>()
+        override this.CanConvert typ = typ = typeof<Declaration>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            ()
+    type NewArrayKindConverter() =
+        inherit Serialization.JsonConverter<NewArrayKind>()
+        override this.CanConvert typ = typ = typeof<NewArrayKind>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            ()
+    type GetKindConverter() =
+        inherit Serialization.JsonConverter<GetKind>()
+        override this.CanConvert typ = typ = typeof<GetKind>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            ()
+    type SetKindConverter() =
+        inherit Serialization.JsonConverter<SetKind>()
+        override this.CanConvert typ = typ = typeof<SetKind>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            ()
+    type TestKindConverter() =
+        inherit Serialization.JsonConverter<TestKind>()
+        override this.CanConvert typ = typ = typeof<TestKind>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            ()
+    type ExtendedSetConverter() =
+        inherit Serialization.JsonConverter<ExtendedSet>()
+        override this.CanConvert typ = typ = typeof<ExtendedSet>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            ()
+    type UnresolvedExprConverter() =
+        inherit Serialization.JsonConverter<UnresolvedExpr>()
+        override this.CanConvert typ = typ = typeof<UnresolvedExpr>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            ()
+    type OperationKindConverter() =
+        inherit Serialization.JsonConverter<OperationKind>()
+        override this.CanConvert typ = typ = typeof<OperationKind>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            ()
+    type NumberKindConverter() =
+        inherit Serialization.JsonConverter<NumberKind>()
+        override this.CanConvert typ = typ = typeof<NumberKind>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            ()
+    type RegexFlagConverter() =
+        inherit Serialization.JsonConverter<RegexFlag>()
+        override this.CanConvert typ = typ = typeof<RegexFlag>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            ()
+    type UnaryOperatorConverter() =
+        inherit Serialization.JsonConverter<UnaryOperator>()
+        override this.CanConvert typ = typ = typeof<UnaryOperator>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            ()
+    type BinaryOperatorConverter() =
+        inherit Serialization.JsonConverter<BinaryOperator>()
+        override this.CanConvert typ = typ = typeof<BinaryOperator>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            ()
+    type LogicalOperatorConverter() =
+        inherit Serialization.JsonConverter<LogicalOperator>()
+        override this.CanConvert typ = typ = typeof<LogicalOperator>
+        override this.Read(_,_,_) = unbox null
+        override this.Write(writer, value, options) =
+            ()
+
+    let options = JsonSerializerOptions(JsonSerializerDefaults.General)
+    options.Converters.Add (EntityPathConverter())
+    options.Converters.Add (MemberRefConverter())
+    options.Converters.Add (GeneratedMemberConverter())
+    options.Converters.Add (NumberInfoConverter())
+    options.Converters.Add (NumberValueConverter())
+    options.Converters.Add (ArrayKindConverter())
+    options.Converters.Add (ConstraintConverter())
+    options.Converters.Add (TypeConverter())
+    options.Converters.Add (ExprConverter())
+    options.Converters.Add (ValueKindConverter())
+    options.Converters.Add (TagSourceConverter())
+    options.Converters.Add (TagInfoConverter())
+    options.Converters.Add (ImportKindConverter())
+    options.Converters.Add (DeclarationConverter())
+    options.Converters.Add (NewArrayKindConverter())
+    options.Converters.Add (GetKindConverter())
+    options.Converters.Add (SetKindConverter())
+    options.Converters.Add (TestKindConverter())
+    options.Converters.Add (ExtendedSetConverter())
+    options.Converters.Add (UnresolvedExprConverter())
+    options.Converters.Add (OperationKindConverter())
+    options.Converters.Add (NumberKindConverter())
+    options.Converters.Add (RegexFlagConverter())
+    options.Converters.Add (UnaryOperatorConverter())
+    options.Converters.Add (BinaryOperatorConverter())
+    options.Converters.Add (LogicalOperatorConverter())
+    /// ANSI Escape Sequences to colorize strings when directed to output.
+    [<AutoOpen>]
+    module private FColor =
+        type private FColor = string
+        /// When the output is not directed to console (ie directed to a file) then the escape sequence is not written
+        let private _fcolor value = if Console.IsOutputRedirected then "" else value
+
+        /// Applies Color to value only. Returns color to normal after.
+        let colorize (color: FColor) (value: string) = $"{color}{value}{NORMAL}"
+        // Presets
+        let NORMAL : FColor =_fcolor "\x1b[39m" // Normal
+        let REVERSE : FColor =_fcolor "\x1b[7m" // Inverts Foreground and Background colors
+        let NOREVERSE : FColor =_fcolor "\x1b[27m" // Reverts Foreground and Background colors
+        // Colors
+        let RED : FColor =_fcolor "\x1b[91m"
+        let GREEN : FColor =_fcolor "\x1b[92m"
+        let YELLOW : FColor =_fcolor "\x1b[93m"
+        let BLUE : FColor =_fcolor "\x1b[94m"
+        let MAGENTA : FColor =_fcolor "\x1b[95m"
+        let CYAN : FColor =_fcolor "\x1b[96m"
+        let GREY : FColor =_fcolor "\x1b[97m"
+        // Formatting
+        let BOLD : FColor =_fcolor "\x1b[1m" // Intense
+        let NOBOLD : FColor =_fcolor "\x1b[22m" // Normal intensity
+        let UNDERLINE : FColor =_fcolor "\x1b[4m" // Underlined
+        let NOUNDERLINE : FColor =_fcolor "\x1b[24m" // Remove any underline
+    type PrettyPrinter =
+        static member print(value: 'T): string = JsonSerializer.Serialize(value, options)

--- a/src/Oxpecker.Solid.FablePlugin/PrettyPrint.fs
+++ b/src/Oxpecker.Solid.FablePlugin/PrettyPrint.fs
@@ -1,561 +1,966 @@
 ﻿namespace Oxpecker.Solid.FablePlugin
 
+// Contains logic to enable JSON conversion and printing of AST to assist
+// in plugin development and debugging.
+//
+// The intention is to provide JSON that can be viewed in a tree structure with any
+// compatible JSON viewing tool
+//
+// There are several CommandLine defines that can be provided to enable and
+// modify this behaviour.
+// The printing of the AST in JSON has a depth limit to provide the relevant depth
+// of information on nodes that are being transformed.
+// Otherwise, you would want to redirect your console output to a file.
+// The tracers, when enabled, emit on most transformations and transitions in the plugin logic,
+// so the output very quickly can become verbose
+//
+// =======
+// DEFINES
+// =======
+// OXPECKER_SOLID_MINIMAL    //* No Json printing, just operation flow is printed
+// OXPECKER_SOLID_DEBUG      //* Max depth of 4 - default
+// OXPECKER_SOLID_DEBUG_1    //* Max depth of 1
+// ''  ''    ''  ''     [n]  //* Max depth of n
+// OXPECKER_SOLID_TRACE      //* No max depth.
+//
+// =======
+// USAGE
+// =======
+// fable --define OXPECKER_SOLID_DEBUG
+
 open System
 open Fable.AST
 open Fable.AST.Fable
 open Types
 open System.Text.Json
 
-module internal rec PrettyPrint =
+[<AutoOpen>]
+module private CompilerDirectives =
+    // Converters can use a simple one liner at the beginning of their Write to see if
+    // 1) they can write (if some debug mode is on; although this wouldnt be reached in that case
+    // 2) the max depth has been reached as per some other definition or directive
+    let private maxDepth: unit -> int = PluginConfiguration.Depth
+    let mutable private _canWrite = fun (writer: Utf8JsonWriter) -> false
+    _canWrite <-
+        fun writer ->
+            if maxDepth() > 0 && writer.CurrentDepth > maxDepth() then
+                writer.WriteRawValue($"\"MAX_DEPTH\"", true)
+                false
+            else
+                true
+    let canWrite = _canWrite
+module private rec PrettyPrint =
+    (*  The Converters are all written the same.
+    The Write logic is wrapped in an `if` statement. It checks against the current depth
+    of the writer with whatever Compiler Directives are enabled to determine if it should
+    proceed. If not, it writes "MAX_DEPTH".
+
+  * We only have to provide converters for the Discriminated Unions (DUs).
+    Whenever writing JSON output, you should assume you are writing in the 'value' position.
+    ie. Wrap all non-value output in an object or array.
+
+  * Remember the output is not supposed to be decodable, or accurately reflect the underlying
+    types.
+
+  * Wrap DUs in an object, not an array.
+    BAD_OUTPUT: ["SourcePath", "value"]
+    GOOD_OUTPUT: {"SourcePath":"value"}
+
+  * Prepend all DUs choices with the root type name.
+    BAD_OUTPUT: {"SourcePath":"value"}
+    GOOD_OUTPUT: {"EntityPath.SourcePath":"value"}
+
+  * If DU tuples are named, it is valuable information on the context of the values.
+    Why wrap them in an array?
+    Wrap them in an anonymous object (with the fields named according to the tuple) and use
+    JsonSerializer. Or, write the object with the field/values set by hand.
+    Obviously simple/single value/non-tupled DUs don't have to do this.
+    BAD_OUTPUT: {"Constraint.HasMember":[{...}, false]}
+    GOOD_OUTPUT: {"Constraint.HasMember":{"name":{...}, "isStatic":false}}                      *)
     type EntityPathConverter() =
         inherit Serialization.JsonConverter<EntityPath>()
         override this.CanConvert typ = typ = typeof<EntityPath>
-        override this.Read(_,_,_) = unbox null
-        override this.Write( writer, value, options ) =
-            let prefix postfix = $"{nameof EntityPath}.{postfix}"
-            match value with
-            | SourcePath s -> writer.WriteString (prefix (nameof SourcePath), s)
-            | AssemblyPath s -> writer.WriteString (prefix (nameof AssemblyPath), s)
-            | CoreAssemblyName s -> writer.WriteString (prefix (nameof CoreAssemblyName), s)
-            | PrecompiledLib(sourcePath, assemblyPath) -> writer.WriteString (prefix (nameof PrecompiledLib), JsonSerializer.Serialize {|sourcePath = sourcePath; assemblyPath = assemblyPath|})
+        override this.Read(_, _, _) = unbox null
+        override this.Write(writer, value, options) =
+            if canWrite writer then
+                let prefix postfix = $"{nameof EntityPath}.{postfix}"
+                writer.WriteStartObject()
+                match value with
+                | SourcePath s -> writer.WriteString(prefix(nameof SourcePath), s)
+                | AssemblyPath s -> writer.WriteString(prefix(nameof AssemblyPath), s)
+                | CoreAssemblyName s -> writer.WriteString(prefix(nameof CoreAssemblyName), s)
+                | PrecompiledLib(sourcePath, assemblyPath) ->
+                    writer.WriteString(
+                        prefix(nameof PrecompiledLib),
+                        JsonSerializer.Serialize {|
+                            sourcePath = sourcePath
+                            assemblyPath = assemblyPath
+                        |}
+                    )
+                writer.WriteEndObject()
     type MemberRefConverter() =
         inherit Serialization.JsonConverter<MemberRef>()
         override this.CanConvert typ = typ = typeof<MemberRef>
-        override this.Read(_,_,_) = unbox null
-        override this.Write( writer, value, options) =
-            let prefix postfix = $"{nameof MemberRef}.{postfix}"
-            match value with
-            | MemberRef(declaringEntity, info) ->
-                let inp = {|declaringEntity=declaringEntity;info=info|}
-                writer.WritePropertyName (prefix (nameof MemberRef))
-                JsonSerializer.Serialize(writer, inp, inp.GetType(), options)
-            | GeneratedMemberRef generatedMember ->
-                nameof GeneratedMemberRef |> prefix |> writer.WritePropertyName
-                JsonSerializer.Serialize(writer, generatedMember, generatedMember.GetType(), options)
+        override this.Read(_, _, _) = unbox null
+        override this.Write(writer, value, options) =
+            if canWrite writer then
+                let prefix postfix = $"{nameof MemberRef}.{postfix}"
+                writer.WriteStartObject()
+                match value with
+                | MemberRef(declaringEntity, info) ->
+                    let inp = {|
+                        declaringEntity = declaringEntity
+                        info = info
+                    |}
+                    writer.WritePropertyName(prefix(nameof MemberRef))
+                    JsonSerializer.Serialize(writer, inp, inp.GetType(), options)
+                | GeneratedMemberRef generatedMember ->
+                    nameof GeneratedMemberRef |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, generatedMember, generatedMember.GetType(), options)
+                writer.WriteEndObject()
     type GeneratedMemberConverter() =
         inherit Serialization.JsonConverter<GeneratedMember>()
         override this.CanConvert typ = typ = typeof<GeneratedMember>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            let prefix postfix = $"{nameof GeneratedMember}.{postfix}"
-            match value with
-            | GeneratedFunction info ->
-                let object = {|GeneratedFunction=info|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | GeneratedValue info ->
-                let object = {|GeneratedValue=info|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | GeneratedGetter info ->
-                let object = {|GeneratedGetter=info|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | GeneratedSetter info ->
-                let object = {|GeneratedSetter=info|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
+            if canWrite writer then
+                let prefix postfix = $"{nameof GeneratedMember}.{postfix}"
+                match value with
+                | GeneratedFunction info ->
+                    let object = {| GeneratedFunction = info |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | GeneratedValue info ->
+                    let object = {| GeneratedValue = info |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | GeneratedGetter info ->
+                    let object = {| GeneratedGetter = info |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | GeneratedSetter info ->
+                    let object = {| GeneratedSetter = info |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
     type NumberInfoConverter() =
         inherit Serialization.JsonConverter<NumberInfo>()
         override this.CanConvert typ = typ = typeof<NumberInfo>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            let prefix postfix = $"{nameof NumberInfo}.{postfix}"
-            match value with
-            | NumberInfo.Empty -> nameof NumberInfo.Empty |> prefix |> writer.WriteNull
-            | NumberInfo.IsMeasure fullname -> nameof NumberInfo.IsMeasure |> prefix |> fun prop -> writer.WriteString (prop, fullname)
-            | NumberInfo.IsEnum ent ->
-                nameof NumberInfo.IsEnum |> prefix |> writer.WritePropertyName
-                JsonSerializer.Serialize(writer, ent, ent.GetType(), options)
+            if canWrite writer then
+                let prefix postfix = $"{nameof NumberInfo}.{postfix}"
+                writer.WriteStartObject()
+                match value with
+                | NumberInfo.Empty -> nameof NumberInfo.Empty |> prefix |> writer.WriteNull
+                | NumberInfo.IsMeasure fullname ->
+                    nameof NumberInfo.IsMeasure
+                    |> prefix
+                    |> fun prop -> writer.WriteString(prop, fullname)
+                | NumberInfo.IsEnum ent ->
+                    nameof NumberInfo.IsEnum |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, ent, ent.GetType(), options)
+                writer.WriteEndObject()
     type NumberValueConverter() =
         inherit Serialization.JsonConverter<NumberValue>()
         override this.CanConvert typ = typ = typeof<NumberValue>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            match value with
-            | NumberValue.Int8 b -> JsonSerializer.Serialize(writer, b, b.GetType(), options)
-            | NumberValue.UInt8 b -> JsonSerializer.Serialize(writer, b, b.GetType(), options)
-            | NumberValue.Int16 s -> JsonSerializer.Serialize(writer, s, s.GetType(), options)
-            | NumberValue.UInt16 s -> JsonSerializer.Serialize(writer, s, s.GetType(), options)
-            | NumberValue.Int32 i -> JsonSerializer.Serialize(writer, i, i.GetType(), options)
-            | NumberValue.UInt32 i -> JsonSerializer.Serialize(writer, i, i.GetType(), options)
-            | NumberValue.Int64 int64 -> JsonSerializer.Serialize(writer, int64, int64.GetType(), options)
-            | NumberValue.UInt64 uInt64 -> JsonSerializer.Serialize(writer, uInt64, uInt64.GetType(), options)
-            | NumberValue.Int128(upper, lower) -> $"{upper}{lower}" |> fun v -> writer.WriteRawValue(v,true)
-            | NumberValue.UInt128(upper, lower) -> $"{upper}{lower}" |> fun v -> writer.WriteRawValue(v,true)
-            | NumberValue.BigInt bigInteger -> JsonSerializer.Serialize(writer, bigInteger, bigInteger.GetType(), options)
-            | NumberValue.NativeInt intPtr -> JsonSerializer.Serialize(writer, intPtr, intPtr.GetType(), options)
-            | NumberValue.UNativeInt uIntPtr -> JsonSerializer.Serialize(writer, uIntPtr, uIntPtr.GetType(), options)
-            | NumberValue.Float16 f -> JsonSerializer.Serialize(writer, f, f.GetType(), options)
-            | NumberValue.Float32 f -> JsonSerializer.Serialize(writer, f, f.GetType(), options)
-            | NumberValue.Float64 f -> JsonSerializer.Serialize(writer, f, f.GetType(), options)
-            | NumberValue.Decimal decimal -> JsonSerializer.Serialize(writer, decimal, decimal.GetType(), options)
+            if canWrite writer then
+                match value with
+                | NumberValue.Int8 b -> JsonSerializer.Serialize(writer, b, typeof<sbyte>, options)
+                | NumberValue.UInt8 b -> JsonSerializer.Serialize(writer, b, typeof<byte>, options)
+                | NumberValue.Int16 s -> JsonSerializer.Serialize(writer, s, typeof<int16>, options)
+                | NumberValue.UInt16 s -> JsonSerializer.Serialize(writer, s, typeof<uint16>, options)
+                | NumberValue.Int32 i -> JsonSerializer.Serialize(writer, i, typeof<int32>, options)
+                | NumberValue.UInt32 i -> JsonSerializer.Serialize(writer, i, typeof<uint32>, options)
+                | NumberValue.Int64 int64 -> JsonSerializer.Serialize(writer, int64, int64.GetType(), options)
+                | NumberValue.UInt64 uInt64 -> JsonSerializer.Serialize(writer, uInt64, uInt64.GetType(), options)
+                | NumberValue.Int128(upper, lower) -> $"{upper}{lower}" |> fun v -> writer.WriteRawValue(v, true)
+                | NumberValue.UInt128(upper, lower) -> $"{upper}{lower}" |> fun v -> writer.WriteRawValue(v, true)
+                | NumberValue.BigInt bigInteger ->
+                    JsonSerializer.Serialize(writer, bigInteger, bigInteger.GetType(), options)
+                | NumberValue.NativeInt intPtr -> JsonSerializer.Serialize(writer, intPtr, intPtr.GetType(), options)
+                | NumberValue.UNativeInt uIntPtr ->
+                    JsonSerializer.Serialize(writer, uIntPtr, uIntPtr.GetType(), options)
+                | NumberValue.Float16 f -> JsonSerializer.Serialize(writer, f, f.GetType(), options)
+                | NumberValue.Float32 f -> JsonSerializer.Serialize(writer, f, f.GetType(), options)
+                | NumberValue.Float64 f -> JsonSerializer.Serialize(writer, f, f.GetType(), options)
+                | NumberValue.Decimal decimal -> JsonSerializer.Serialize(writer, decimal, decimal.GetType(), options)
     type ArrayKindConverter() =
         inherit Serialization.JsonConverter<ArrayKind>()
         override this.CanConvert typ = typ = typeof<ArrayKind>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            match value with
-            | ResizeArray -> nameof ResizeArray
-            | MutableArray -> nameof MutableArray
-            | ImmutableArray -> nameof ImmutableArray
-            |> fun value -> writer.WriteString (nameof ArrayKind,value)
+            if canWrite writer then
+                writer.WriteStartObject()
+                match value with
+                | ResizeArray -> nameof ResizeArray
+                | MutableArray -> nameof MutableArray
+                | ImmutableArray -> nameof ImmutableArray
+                |> fun value -> writer.WriteString(nameof ArrayKind, value)
+                writer.WriteEndObject()
     type ConstraintConverter() =
         inherit Serialization.JsonConverter<Constraint>()
         override this.CanConvert typ = typ = typeof<Constraint>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            let wrap input = $"\"{input}\""
-            writer.WriteStartObject()
-            match value with
-            | Constraint.HasMember(name, isStatic) ->
-                writer.WritePropertyName $"{nameof Constraint}.{nameof Constraint.HasMember}"
-                let object = {|name=name;isStatic=isStatic|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Constraint.CoercesTo target ->
-                writer.WritePropertyName $"{nameof Constraint}.{nameof Constraint.CoercesTo}"
-                // JsonSerializer.Serialize(writer, target, target.GetType(), options)
-            | Constraint.IsNullable ->
-                let object = wrap $"{nameof Constraint}.{nameof Constraint.IsNullable}"
-                writer.WriteRawValue(object, true)
-            | Constraint.IsValueType ->
-                let object = wrap $"{nameof Constraint}.{nameof Constraint.IsValueType}"
-                writer.WriteRawValue(object, true)
-            | Constraint.IsReferenceType ->
-                let object = wrap $"{nameof Constraint}.{nameof Constraint.IsReferenceType}"
-                writer.WriteRawValue(object, true)
-            | Constraint.HasDefaultConstructor ->
-                let object = wrap $"{nameof Constraint}.{nameof Constraint.HasDefaultConstructor}"
-                writer.WriteRawValue(object, true)
-            | Constraint.HasComparison ->
-                let object = wrap $"{nameof Constraint}.{nameof Constraint.HasComparison}"
-                writer.WriteRawValue(object, true)
-            | Constraint.HasEquality ->
-                let object = wrap $"{nameof Constraint}.{nameof Constraint.HasEquality}"
-                writer.WriteRawValue(object, true)
-            | Constraint.IsUnmanaged ->
-                let object = wrap $"{nameof Constraint}.{nameof Constraint.IsUnmanaged}"
-                writer.WriteRawValue(object, true)
-            | Constraint.IsEnum ->
-                let object = wrap $"{nameof Constraint}.{nameof Constraint.IsEnum}"
-                writer.WriteRawValue(object, true)
-            writer.WriteEndObject()
+            if canWrite writer then
+                let wrap input = $"\"{input}\""
+                writer.WriteStartObject()
+                match value with
+                | Constraint.HasMember(name, isStatic) ->
+                    writer.WritePropertyName $"{nameof Constraint}.{nameof Constraint.HasMember}"
+                    let object = {| name = name; isStatic = isStatic |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | Constraint.CoercesTo target ->
+                    writer.WritePropertyName $"{nameof Constraint}.{nameof Constraint.CoercesTo}"
+                    JsonSerializer.Serialize(writer, target, typeof<Fable.Type>, options)
+                | Constraint.IsNullable ->
+                    let object = wrap $"{nameof Constraint}.{nameof Constraint.IsNullable}"
+                    writer.WriteRawValue(object, true)
+                | Constraint.IsValueType ->
+                    let object = wrap $"{nameof Constraint}.{nameof Constraint.IsValueType}"
+                    writer.WriteRawValue(object, true)
+                | Constraint.IsReferenceType ->
+                    let object = wrap $"{nameof Constraint}.{nameof Constraint.IsReferenceType}"
+                    writer.WriteRawValue(object, true)
+                | Constraint.HasDefaultConstructor ->
+                    let object = wrap $"{nameof Constraint}.{nameof Constraint.HasDefaultConstructor}"
+                    writer.WriteRawValue(object, true)
+                | Constraint.HasComparison ->
+                    let object = wrap $"{nameof Constraint}.{nameof Constraint.HasComparison}"
+                    writer.WriteRawValue(object, true)
+                | Constraint.HasEquality ->
+                    let object = wrap $"{nameof Constraint}.{nameof Constraint.HasEquality}"
+                    writer.WriteRawValue(object, true)
+                | Constraint.IsUnmanaged ->
+                    let object = wrap $"{nameof Constraint}.{nameof Constraint.IsUnmanaged}"
+                    writer.WriteRawValue(object, true)
+                | Constraint.IsEnum ->
+                    let object = wrap $"{nameof Constraint}.{nameof Constraint.IsEnum}"
+                    writer.WriteRawValue(object, true)
+                writer.WriteEndObject()
     type TypeConverter() =
         inherit Serialization.JsonConverter<Fable.Type>()
         override this.CanConvert typ = typ = typeof<Fable.Type>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            let wrap input = $"\"{input}\""
-            let prefix postfix = $"{nameof Fable.Type}.{postfix}"
-            writer.WriteStartObject()
-            match value with
-            | Type.Measure fullname -> writer.WriteString(prefix (nameof Measure), fullname)
-            | Type.MetaType -> let object = (nameof MetaType) |> prefix |> wrap in writer.WriteRawValue(object, true)
-            | Type.Any -> let object = (nameof Any) |> prefix |> wrap in writer.WriteRawValue(object, true)
-            | Type.Unit -> let object = (nameof Unit) |> prefix |> wrap in writer.WriteRawValue(object, true)
-            | Type.Boolean -> let object = (nameof Boolean) |> prefix |> wrap in writer.WriteRawValue(object, true)
-            | Type.Char -> let object = (nameof Char) |> prefix |> wrap in writer.WriteRawValue(object, true)
-            | Type.String -> let object = (nameof String) |> prefix |> wrap in writer.WriteRawValue(object, true)
-            | Type.Regex -> let object = (nameof Regex) |> prefix |> wrap in writer.WriteRawValue(object, true)
-            | Type.Number(kind, info) ->
-                writer.WritePropertyName (prefix (nameof Number))
-                let object = {|kind=kind;info=info|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Type.Option(genericArg, isStruct) ->
-                writer.WritePropertyName (prefix (nameof Option))
-                let object = {|genericArg=genericArg;isStruct=isStruct|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Type.Tuple(genericArgs, isStruct) ->
-                writer.WritePropertyName (prefix (nameof Tuple))
-                let object = {|genericArgs=genericArgs;isStruct=isStruct|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Type.Array(genericArg, kind) ->
-                writer.WritePropertyName (prefix (nameof Array))
-                let object = {|genericArg=genericArg;kind=kind|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Type.List genericArg ->
-                writer.WritePropertyName (prefix (nameof List))
-                let object = {|genericArg=genericArg|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Type.LambdaType(argType, returnType) ->
-                writer.WritePropertyName (prefix (nameof LambdaType))
-                let object = {|argType=argType; returnType=returnType|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Type.DelegateType(argTypes, returnType) ->
-                writer.WritePropertyName (prefix (nameof DelegateType))
-                let object = {|argTypes=argTypes; returnType=returnType|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Type.GenericParam(name, isMeasure, constraints) ->
-                writer.WritePropertyName (prefix (nameof GenericParam))
-                let object = {|name=name;isMeasure=isMeasure;constraints=constraints|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Type.DeclaredType(rref, genericArgs) ->
-                writer.WritePropertyName (prefix (nameof DeclaredType))
-                let object = {|rref=rref;genericArgs=genericArgs|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Type.AnonymousRecordType(fieldNames, genericArgs, isStruct) ->
-                writer.WritePropertyName (prefix (nameof AnonymousRecordType))
-                let object = {|fieldNames=fieldNames;genericArgs=genericArgs;isStruct=isStruct|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            writer.WriteEndObject()
+            if canWrite writer then
+                let wrap input = $"\"{input}\""
+                let prefix postfix = $"{nameof Fable.Type}.{postfix}"
+                match value with
+                | Type.Measure fullname -> writer.WriteString(prefix(nameof Measure), fullname)
+                | Type.MetaType ->
+                    let object = (nameof MetaType) |> prefix |> wrap in writer.WriteRawValue(object, true)
+                | Type.Any -> let object = (nameof Any) |> prefix |> wrap in writer.WriteRawValue(object, true)
+                | Type.Unit -> let object = (nameof Unit) |> prefix |> wrap in writer.WriteRawValue(object, true)
+                | Type.Boolean -> let object = (nameof Boolean) |> prefix |> wrap in writer.WriteRawValue(object, true)
+                | Type.Char -> let object = (nameof Char) |> prefix |> wrap in writer.WriteRawValue(object, true)
+                | Type.String -> let object = (nameof String) |> prefix |> wrap in writer.WriteRawValue(object, true)
+                | Type.Regex -> let object = (nameof Regex) |> prefix |> wrap in writer.WriteRawValue(object, true)
+                | Type.Number(kind, info) ->
+                    writer.WriteStartObject()
+                    writer.WritePropertyName(prefix(nameof Number))
+                    let object = {| kind = kind; info = info |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                    writer.WriteEndObject()
+                | Type.Option(genericArg, isStruct) ->
+                    writer.WriteStartObject()
+                    writer.WritePropertyName(prefix(nameof Option))
+                    let object = {|
+                        genericArg = genericArg
+                        isStruct = isStruct
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                    writer.WriteEndObject()
+                | Type.Tuple(genericArgs, isStruct) ->
+                    writer.WriteStartObject()
+                    writer.WritePropertyName(prefix(nameof Tuple))
+                    let object = {|
+                        genericArgs = genericArgs
+                        isStruct = isStruct
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                    writer.WriteEndObject()
+                | Type.Array(genericArg, kind) ->
+                    writer.WriteStartObject()
+                    writer.WritePropertyName(prefix(nameof Array))
+                    let object = {|
+                        genericArg = genericArg
+                        kind = kind
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                    writer.WriteEndObject()
+                | Type.List genericArg ->
+                    writer.WriteStartObject()
+                    writer.WritePropertyName(prefix(nameof List))
+                    let object = {| genericArg = genericArg |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                    writer.WriteEndObject()
+                | Type.LambdaType(argType, returnType) ->
+                    writer.WriteStartObject()
+                    writer.WritePropertyName(prefix(nameof LambdaType))
+                    let object = {|
+                        argType = argType
+                        returnType = returnType
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                    writer.WriteEndObject()
+                | Type.DelegateType(argTypes, returnType) ->
+                    writer.WriteStartObject()
+                    writer.WritePropertyName(prefix(nameof DelegateType))
+                    let object = {|
+                        argTypes = argTypes
+                        returnType = returnType
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                    writer.WriteEndObject()
+                | Type.GenericParam(name, isMeasure, constraints) ->
+                    writer.WriteStartObject()
+                    writer.WritePropertyName(prefix(nameof GenericParam))
+                    let object = {|
+                        name = name
+                        isMeasure = isMeasure
+                        constraints = constraints
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                    writer.WriteEndObject()
+                | Type.DeclaredType(rref, genericArgs) ->
+                    writer.WriteStartObject()
+                    writer.WritePropertyName(prefix(nameof DeclaredType))
+                    let object = {|
+                        rref = rref
+                        genericArgs = genericArgs
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                    writer.WriteEndObject()
+                | Type.AnonymousRecordType(fieldNames, genericArgs, isStruct) ->
+                    writer.WriteStartObject()
+                    writer.WritePropertyName(prefix(nameof AnonymousRecordType))
+                    let object = {|
+                        fieldNames = fieldNames
+                        genericArgs = genericArgs
+                        isStruct = isStruct
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                    writer.WriteEndObject()
     type ExprConverter() =
         inherit Serialization.JsonConverter<Expr>()
         override this.CanConvert typ = typ = typeof<Expr>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            let prefix postfix = $"{nameof Expr}.{postfix}"
-            let wrap input = $"\"{input}\""
-            writer.WriteStartObject()
-            match value with
-            | IdentExpr ident ->
-                writer.WritePropertyName(prefix(nameof IdentExpr))
-                JsonSerializer.Serialize(writer, ident, ident.GetType(), options)
-            | Value(kind, range) ->
-                writer.WritePropertyName(prefix(nameof Value))
-                let object = {|kind=kind;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Lambda(arg, body, name) ->
-                writer.WritePropertyName(prefix(nameof Lambda))
-                let object = {|arg=arg;body=body;name=name|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Delegate(args, body, name, tags) ->
-                writer.WritePropertyName(prefix(nameof Delegate))
-                let object = {|args=args;body=body;name=name;tags=tags|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | ObjectExpr(members, typ, baseCall) ->
-                writer.WritePropertyName(prefix(nameof ObjectExpr))
-                let object = {|members=members;``type``=typ;baseCall=baseCall|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | TypeCast(expr, typ) ->
-                writer.WritePropertyName(prefix(nameof TypeCast))
-                let object = {|expr=expr;``type``=typ|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Test(expr, kind, range) ->
-                writer.WritePropertyName(prefix(nameof Test))
-                let object = {|expr=expr;kind=kind;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Call(callee, info, typ, range) ->
-                writer.WritePropertyName(prefix(nameof Call))
-                let object = {|callee=callee;info=info;``type``=typ;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | CurriedApply(applied, args, typ, range) ->
-                writer.WritePropertyName(prefix(nameof CurriedApply))
-                let object = {|applied=applied;args=args;``type``=typ;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Operation(kind, tags, typ, range) ->
-                writer.WritePropertyName(prefix(nameof Operation))
-                let object = {|kind=kind;tags=tags;``type``=typ;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Import(info, typ, range) ->
-                writer.WritePropertyName(prefix(nameof Import))
-                let object = {|info=info;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Emit(info, typ, range) ->
-                writer.WritePropertyName(prefix(nameof Emit))
-                let object = {|info=info;``type``=typ;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | DecisionTree(expr, targets) ->
-                writer.WritePropertyName(prefix(nameof DecisionTree))
-                let object = {|expr=expr;targets=targets|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | DecisionTreeSuccess(targetIndex, boundValues, typ) ->
-                writer.WritePropertyName(prefix(nameof DecisionTreeSuccess))
-                let object = {|targetIndex=targetIndex;boundValues=boundValues;``type``=typ|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Let(ident, value, body) ->
-                writer.WritePropertyName(prefix(nameof Let))
-                let object = {|ident=ident;value=value;body=body|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | LetRec(bindings, body) ->
-                writer.WritePropertyName(prefix(nameof LetRec))
-                let object = {|bindings=bindings;body=body|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Get(expr, kind, typ, range) ->
-                writer.WritePropertyName(prefix(nameof Get))
-                let object = {|expr=expr;kind=kind;``type``=typ;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Set(expr, kind, typ, value, range) ->
-                writer.WritePropertyName(prefix(nameof Set))
-                let object = {|expr=expr;kind=kind;``type``=typ;value=value;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Sequential exprs ->
-                writer.WritePropertyName(prefix(nameof Sequential))
-                let object = exprs
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | WhileLoop(guard, body, range) ->
-                writer.WritePropertyName(prefix(nameof WhileLoop))
-                let object = {|guard=guard;body=body;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | ForLoop(ident, start, limit, body, isUp, range) ->
-                writer.WritePropertyName(prefix(nameof ForLoop))
-                let object = {|ident=ident;start=start;limit=limit;body=body;isUp=isUp;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | TryCatch(body, catch, finalizer, range) ->
-                writer.WritePropertyName(prefix(nameof TryCatch))
-                let object = {|body=body;catch=catch;finalizer=finalizer;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | IfThenElse(guardExpr, thenExpr, elseExpr, range) ->
-                writer.WritePropertyName(prefix(nameof IfThenElse))
-                let object = {|guardExpr=guardExpr;thenExpr=thenExpr;elseExpr=elseExpr;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Unresolved(expr, typ, range) ->
-                writer.WritePropertyName(prefix(nameof Unresolved))
-                let object = {|expr=expr;``type``=typ;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Extended(expr, range) ->
-                writer.WritePropertyName(prefix(nameof Extended))
-                let object = {|expr=expr;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            writer.WriteEndObject()
+            if canWrite writer then
+                let prefix postfix = $"{nameof Expr}.{postfix}"
+                writer.WriteStartObject()
+                match value with
+                | IdentExpr ident ->
+                    writer.WritePropertyName(prefix(nameof IdentExpr))
+                    JsonSerializer.Serialize(writer, ident, ident.GetType(), options)
+                | Value(kind, range) ->
+                    writer.WritePropertyName(prefix(nameof Value))
+                    let object = {| kind = kind; range = range |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | Lambda(arg, body, name) ->
+                    writer.WritePropertyName(prefix(nameof Lambda))
+                    let object = {|
+                        arg = arg
+                        body = body
+                        name = name
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | Delegate(args, body, name, tags) ->
+                    writer.WritePropertyName(prefix(nameof Delegate))
+                    let object = {|
+                        args = args
+                        body = body
+                        name = name
+                        tags = tags
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | ObjectExpr(members, typ, baseCall) ->
+                    writer.WritePropertyName(prefix(nameof ObjectExpr))
+                    let object = {|
+                        members = members
+                        ``type`` = typ
+                        baseCall = baseCall
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | TypeCast(expr, typ) ->
+                    writer.WritePropertyName(prefix(nameof TypeCast))
+                    let object = {| expr = expr; ``type`` = typ |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | Test(expr, kind, range) ->
+                    writer.WritePropertyName(prefix(nameof Test))
+                    let object = {|
+                        expr = expr
+                        kind = kind
+                        range = range
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | Call(callee, info, typ, range) ->
+                    writer.WritePropertyName(prefix(nameof Call))
+                    let object = {|
+                        callee = callee
+                        info = info
+                        ``type`` = typ
+                        range = range
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | CurriedApply(applied, args, typ, range) ->
+                    writer.WritePropertyName(prefix(nameof CurriedApply))
+                    let object = {|
+                        applied = applied
+                        args = args
+                        ``type`` = typ
+                        range = range
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | Operation(kind, tags, typ, range) ->
+                    writer.WritePropertyName(prefix(nameof Operation))
+                    let object = {|
+                        kind = kind
+                        tags = tags
+                        ``type`` = typ
+                        range = range
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | Import(info, typ, range) ->
+                    writer.WritePropertyName(prefix(nameof Import))
+                    let object = {| info = info; range = range |}
+                    writer.WriteStartObject()
+                    writer.WritePropertyName "info"
+                    JsonSerializer.Serialize(writer, info, typeof<ImportInfo>, options)
+                    writer.WritePropertyName "type"
+                    JsonSerializer.Serialize(writer, typ, typeof<Fable.Type>, options)
+                    writer.WritePropertyName "range"
+                    JsonSerializer.Serialize(writer, range, typeof<SourceLocation option>, options)
+                    writer.WriteEndObject()
+                | Emit(info, typ, range) ->
+                    writer.WritePropertyName(prefix(nameof Emit))
+                    let object = {|
+                        info = info
+                        ``type`` = typ
+                        range = range
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | DecisionTree(expr, targets) ->
+                    writer.WritePropertyName(prefix(nameof DecisionTree))
+                    let object = {| expr = expr; targets = targets |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | DecisionTreeSuccess(targetIndex, boundValues, typ) ->
+                    writer.WritePropertyName(prefix(nameof DecisionTreeSuccess))
+                    let object = {|
+                        targetIndex = targetIndex
+                        boundValues = boundValues
+                        ``type`` = typ
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | Let(ident, value, body) ->
+                    writer.WritePropertyName(prefix(nameof Let))
+                    let object = {|
+                        ident = ident
+                        value = value
+                        body = body
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | LetRec(bindings, body) ->
+                    writer.WritePropertyName(prefix(nameof LetRec))
+                    let object = {| bindings = bindings; body = body |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | Get(expr, kind, typ, range) ->
+                    writer.WritePropertyName(prefix(nameof Get))
+                    let object = {|
+                        expr = expr
+                        kind = kind
+                        ``type`` = typ
+                        range = range
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | Set(expr, kind, typ, value, range) ->
+                    writer.WritePropertyName(prefix(nameof Set))
+                    let object = {|
+                        expr = expr
+                        kind = kind
+                        ``type`` = typ
+                        value = value
+                        range = range
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | Sequential exprs ->
+                    writer.WritePropertyName(prefix(nameof Sequential))
+                    let object = exprs
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | WhileLoop(guard, body, range) ->
+                    writer.WritePropertyName(prefix(nameof WhileLoop))
+                    let object = {|
+                        guard = guard
+                        body = body
+                        range = range
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | ForLoop(ident, start, limit, body, isUp, range) ->
+                    writer.WritePropertyName(prefix(nameof ForLoop))
+                    let object = {|
+                        ident = ident
+                        start = start
+                        limit = limit
+                        body = body
+                        isUp = isUp
+                        range = range
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | TryCatch(body, catch, finalizer, range) ->
+                    writer.WritePropertyName(prefix(nameof TryCatch))
+                    let object = {|
+                        body = body
+                        catch = catch
+                        finalizer = finalizer
+                        range = range
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | IfThenElse(guardExpr, thenExpr, elseExpr, range) ->
+                    writer.WritePropertyName(prefix(nameof IfThenElse))
+                    let object = {|
+                        guardExpr = guardExpr
+                        thenExpr = thenExpr
+                        elseExpr = elseExpr
+                        range = range
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | Unresolved(expr, typ, range) ->
+                    writer.WritePropertyName(prefix(nameof Unresolved))
+                    let object = {|
+                        expr = expr
+                        ``type`` = typ
+                        range = range
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | Extended(expr, range) ->
+                    writer.WritePropertyName(prefix(nameof Extended))
+                    let object = {| expr = expr; range = range |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                writer.WriteEndObject()
     type ValueKindConverter() =
         inherit Serialization.JsonConverter<ValueKind>()
         override this.CanConvert typ = typ = typeof<ValueKind>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            let prefix postfix = $"{nameof ValueKind}.{postfix}"
-            let wrap input = $"\"{input}\""
-            writer.WriteStartObject()
-            match value with
-            | ThisValue typ ->
-                nameof ThisValue |> prefix |> wrap |> writer.WritePropertyName
-                let object = typ
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | BaseValue(boundIdent, typ) ->
-                nameof BaseValue |> prefix |> wrap |> writer.WritePropertyName
-                let object = {|boundIdent=boundIdent;``type``=typ|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | TypeInfo(typ, tags) ->
-                nameof TypeInfo |> prefix |> wrap |> writer.WritePropertyName
-                let object = {|``type``=typ;tags=tags|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Null typ ->
-                nameof Null |> prefix |> wrap |> writer.WritePropertyName
-                let object = typ
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | UnitConstant ->
-                nameof UnitConstant |> prefix |> wrap |> writer.WritePropertyName
-                let object = ()
-                JsonSerializer.Serialize(writer, object, typeof<unit>, options)
-            | BoolConstant value ->
-                nameof BoolConstant |> prefix |> wrap |> writer.WritePropertyName
-                let object = value
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | CharConstant value ->
-                nameof CharConstant |> prefix |> wrap |> writer.WritePropertyName
-                let object = value
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | StringConstant value ->
-                nameof StringConstant |> prefix |> wrap |> writer.WritePropertyName
-                let object = value
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | StringTemplate(tag, parts, values) ->
-                nameof StringTemplate |> prefix |> wrap |> writer.WritePropertyName
-                let object = {|tag=tag;parts=parts;values=values|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | NumberConstant(value, info) ->
-                nameof NumberConstant |> prefix |> wrap |> writer.WritePropertyName
-                let object = {|value=value;info=info|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | RegexConstant(source, flags) ->
-                nameof RegexConstant |> prefix |> wrap |> writer.WritePropertyName
-                let object = {|source=source;flags=flags|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | NewOption(value, typ, isStruct) ->
-                nameof NewOption |> prefix |> wrap |> writer.WritePropertyName
-                let object = {|value=value;``type``=typ;isStruct=isStruct|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | NewArray(newKind, typ, kind) ->
-                nameof NewArray |> prefix |> wrap |> writer.WritePropertyName
-                let object = {|newKind=newKind;``type``=typ;kind=kind|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | NewList(headAndTail, typ) ->
-                nameof NewList |> prefix |> wrap |> writer.WritePropertyName
-                let object = {|headAndTail=headAndTail;``type``=typ|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | NewTuple(values, isStruct) ->
-                nameof NewTuple |> prefix |> wrap |> writer.WritePropertyName
-                let object = {|values=values;isStruct=isStruct|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | NewRecord(values, rref, genArgs) ->
-                nameof NewRecord |> prefix |> wrap |> writer.WritePropertyName
-                let object = {|values=values;rref=rref;genArgs=genArgs|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | NewAnonymousRecord(values, fieldNames, genArgs, isStruct) ->
-                nameof NewAnonymousRecord |> prefix |> wrap |> writer.WritePropertyName
-                let object = {|values=values;fieldNames=fieldNames;genArgs=genArgs;isStruct=isStruct|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | NewUnion(values, tag, rref, genArgs) ->
-                nameof NewUnion |> prefix |> wrap |> writer.WritePropertyName
-                let object = {|values=values;tag=tag;rref=rref;genArgs=genArgs|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            writer.WriteEndObject()
+            if canWrite writer then
+                let prefix postfix = $"{nameof ValueKind}.{postfix}"
+                let wrap input = $"\"{input}\""
+                writer.WriteStartObject()
+                match value with
+                | ThisValue typ ->
+                    nameof ThisValue |> prefix |> wrap |> writer.WritePropertyName
+                    let object = typ
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | BaseValue(boundIdent, typ) ->
+                    nameof BaseValue |> prefix |> wrap |> writer.WritePropertyName
+                    let object = {|
+                        boundIdent = boundIdent
+                        ``type`` = typ
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | TypeInfo(typ, tags) ->
+                    nameof TypeInfo |> prefix |> wrap |> writer.WritePropertyName
+                    let object = {| ``type`` = typ; tags = tags |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | Null typ ->
+                    nameof Null |> prefix |> wrap |> writer.WritePropertyName
+                    let object = typ
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | UnitConstant ->
+                    nameof UnitConstant |> prefix |> wrap |> writer.WritePropertyName
+                    let object = ()
+                    JsonSerializer.Serialize(writer, object, typeof<unit>, options)
+                | BoolConstant value ->
+                    nameof BoolConstant |> prefix |> wrap |> writer.WritePropertyName
+                    let object = value
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | CharConstant value ->
+                    nameof CharConstant |> prefix |> wrap |> writer.WritePropertyName
+                    let object = value
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | StringConstant value ->
+                    nameof StringConstant |> prefix |> wrap |> writer.WritePropertyName
+                    let object = value
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | StringTemplate(tag, parts, values) ->
+                    nameof StringTemplate |> prefix |> wrap |> writer.WritePropertyName
+                    let object = {|
+                        tag = tag
+                        parts = parts
+                        values = values
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | NumberConstant(value, info) ->
+                    nameof NumberConstant |> prefix |> wrap |> writer.WritePropertyName
+                    let object = {| value = value; info = info |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | RegexConstant(source, flags) ->
+                    nameof RegexConstant |> prefix |> wrap |> writer.WritePropertyName
+                    let object = {| source = source; flags = flags |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | NewOption(value, typ, isStruct) ->
+                    nameof NewOption |> prefix |> wrap |> writer.WritePropertyName
+                    let object = {|
+                        value = value
+                        ``type`` = typ
+                        isStruct = isStruct
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | NewArray(newKind, typ, kind) ->
+                    nameof NewArray |> prefix |> wrap |> writer.WritePropertyName
+                    let object = {|
+                        newKind = newKind
+                        ``type`` = typ
+                        kind = kind
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | NewList(headAndTail, typ) ->
+                    nameof NewList |> prefix |> wrap |> writer.WritePropertyName
+                    let object = {|
+                        headAndTail = headAndTail
+                        ``type`` = typ
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | NewTuple(values, isStruct) ->
+                    nameof NewTuple |> prefix |> wrap |> writer.WritePropertyName
+                    let object = {|
+                        values = values
+                        isStruct = isStruct
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | NewRecord(values, rref, genArgs) ->
+                    nameof NewRecord |> prefix |> wrap |> writer.WritePropertyName
+                    let object = {|
+                        values = values
+                        rref = rref
+                        genArgs = genArgs
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | NewAnonymousRecord(values, fieldNames, genArgs, isStruct) ->
+                    nameof NewAnonymousRecord |> prefix |> wrap |> writer.WritePropertyName
+                    let object = {|
+                        values = values
+                        fieldNames = fieldNames
+                        genArgs = genArgs
+                        isStruct = isStruct
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | NewUnion(values, tag, rref, genArgs) ->
+                    nameof NewUnion |> prefix |> wrap |> writer.WritePropertyName
+                    let object = {|
+                        values = values
+                        tag = tag
+                        rref = rref
+                        genArgs = genArgs
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                writer.WriteEndObject()
     type TagSourceConverter() =
         inherit Serialization.JsonConverter<TagSource>()
         override this.CanConvert typ = typ = typeof<TagSource>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            let prefix postfix = $"{nameof TagSource}.{postfix}"
-            writer.WriteStartObject()
-            match value with
-            | AutoImport tagName -> writer.WriteString(prefix (nameof AutoImport), tagName)
-            | LibraryImport imp ->
-                writer.WritePropertyName (prefix (nameof LibraryImport))
-                JsonSerializer.Serialize(writer, imp, typeof<Expr>, options)
-            writer.WriteEndObject()
+            if canWrite writer then
+                let prefix postfix = $"{nameof TagSource}.{postfix}"
+                writer.WriteStartObject()
+                match value with
+                | AutoImport tagName -> writer.WriteString(prefix(nameof AutoImport), tagName)
+                | LibraryImport imp ->
+                    writer.WritePropertyName(prefix(nameof LibraryImport))
+                    JsonSerializer.Serialize(writer, imp, typeof<Expr>, options)
+                writer.WriteEndObject()
     type TagInfoConverter() =
         inherit Serialization.JsonConverter<TagInfo>()
         override this.CanConvert typ = typ = typeof<TagInfo>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            let prefix postfix = $"{nameof TagInfo}.{postfix}"
-            writer.WriteStartObject()
-            match value with
-            | WithChildren(tagName, propsAndChildren, range) ->
-                nameof WithChildren |> prefix |> writer.WritePropertyName
-                let object = {|tagName=tagName;propsAndChildren=propsAndChildren;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | NoChildren(tagName, props, range) ->
-                nameof NoChildren |> prefix |> writer.WritePropertyName
-                let object = {|tagName=tagName;props=props;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            | Combined(tagName, props, propsAndChildren, range) ->
-                nameof Combined |> prefix |> writer.WritePropertyName
-                let object = {|tagName=tagName;props=props;propsAndChildren=propsAndChildren;range=range|}
-                JsonSerializer.Serialize(writer, object, object.GetType(), options)
-            writer.WriteEndObject()
+            if canWrite writer then
+                let prefix postfix = $"{nameof TagInfo}.{postfix}"
+                writer.WriteStartObject()
+                match value with
+                | WithChildren(tagName, propsAndChildren, range) ->
+                    nameof WithChildren |> prefix |> writer.WritePropertyName
+                    let object = {|
+                        tagName = tagName
+                        propsAndChildren = propsAndChildren
+                        range = range
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | NoChildren(tagName, props, range) ->
+                    nameof NoChildren |> prefix |> writer.WritePropertyName
+                    let object = {|
+                        tagName = tagName
+                        props = props
+                        range = range
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                | Combined(tagName, props, propsAndChildren, range) ->
+                    nameof Combined |> prefix |> writer.WritePropertyName
+                    let object = {|
+                        tagName = tagName
+                        props = props
+                        propsAndChildren = propsAndChildren
+                        range = range
+                    |}
+                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
+                writer.WriteEndObject()
     type ImportKindConverter() =
         inherit Serialization.JsonConverter<ImportKind>()
         override this.CanConvert typ = typ = typeof<ImportKind>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            ()
+            if canWrite writer then
+                let prefix postfix = $"{nameof ImportKind}.{postfix}"
+                let wrap input = $"\"{input}\""
+                match value with
+                | UserImport isInline -> nameof UserImport |> prefix |> wrap |> (fun v -> writer.WriteRawValue(v, true))
+                | ImportKind.LibraryImport info ->
+                    writer.WriteStartObject()
+                    nameof ImportKind.LibraryImport |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, info, typeof<LibraryImportInfo>, options)
+                    writer.WriteEndObject()
+                | MemberImport memberRef ->
+                    writer.WriteStartObject()
+                    nameof MemberImport |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, memberRef, typeof<MemberRef>, options)
+                    writer.WriteEndObject()
+                | ClassImport entRef ->
+                    writer.WriteStartObject()
+                    nameof ClassImport |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, entRef, typeof<EntityRef>, options)
+                    writer.WriteEndObject()
     type DeclarationConverter() =
         inherit Serialization.JsonConverter<Declaration>()
         override this.CanConvert typ = typ = typeof<Declaration>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            ()
+            if canWrite writer then
+                let prefix postfix = $"{nameof Declaration}.{postfix}"
+                let wrap input = $"\"{input}\""
+                writer.WriteStartObject()
+                match value with
+                | ModuleDeclaration moduleDecl ->
+                    nameof ModuleDeclaration |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, moduleDecl, typeof<ModuleDecl>, options)
+                | ActionDeclaration actionDecl ->
+                    nameof ActionDeclaration |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, actionDecl, typeof<ActionDecl>, options)
+                | MemberDeclaration memberDecl ->
+                    nameof MemberDeclaration |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, memberDecl, typeof<MemberDecl>, options)
+                | ClassDeclaration classDecl ->
+                    nameof ClassDeclaration |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, classDecl, typeof<ClassDecl>, options)
+                writer.WriteEndObject()
     type NewArrayKindConverter() =
         inherit Serialization.JsonConverter<NewArrayKind>()
         override this.CanConvert typ = typ = typeof<NewArrayKind>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            ()
+            if canWrite writer then
+                let prefix postfix = $"{nameof NewArrayKind}.{postfix}"
+                let wrap input = $"\"{input}\""
+                writer.WriteStartObject()
+                match value with
+                | ArrayValues values ->
+                    nameof ArrayValues |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, values, typeof<Expr list>, options)
+                | ArrayAlloc size ->
+                    nameof ArrayAlloc |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, size, typeof<Expr>, options)
+                | ArrayFrom expr ->
+                    nameof ArrayFrom |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, expr, typeof<Expr>, options)
+                writer.WriteEndObject()
     type GetKindConverter() =
         inherit Serialization.JsonConverter<GetKind>()
         override this.CanConvert typ = typ = typeof<GetKind>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            ()
+            if canWrite writer then
+                let prefix postfix = $"{nameof GetKind}.{postfix}"
+                let wrap input = $"\"{input}\""
+                match value with
+                | TupleIndex index ->
+                    writer.WriteStartObject()
+                    nameof TupleIndex |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, index, typeof<int>, options)
+                    writer.WriteEndObject()
+                | ExprGet expr ->
+                    writer.WriteStartObject()
+                    nameof ExprGet |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, expr, typeof<Expr>, options)
+                    writer.WriteEndObject()
+                | FieldGet info ->
+                    writer.WriteStartObject()
+                    nameof FieldGet |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, info, typeof<FieldInfo>, options)
+                    writer.WriteEndObject()
+                | UnionField info ->
+                    writer.WriteStartObject()
+                    nameof UnionField |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, info, typeof<UnionFieldInfo>, options)
+                    writer.WriteEndObject()
+                | UnionTag -> nameof UnionTag |> prefix |> wrap |> (fun v -> writer.WriteRawValue(v, true))
+                | ListHead -> nameof ListHead |> prefix |> wrap |> (fun v -> writer.WriteRawValue(v, true))
+                | ListTail -> nameof ListTail |> prefix |> wrap |> (fun v -> writer.WriteRawValue(v, true))
+                | OptionValue -> nameof OptionValue |> prefix |> wrap |> (fun v -> writer.WriteRawValue(v, true))
     type SetKindConverter() =
         inherit Serialization.JsonConverter<SetKind>()
         override this.CanConvert typ = typ = typeof<SetKind>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            ()
+            if canWrite writer then
+                let prefix postfix = $"{nameof SetKind}.{postfix}"
+                let wrap input = $"\"{input}\""
+                match value with
+                | ExprSet expr ->
+                    writer.WriteStartObject()
+                    nameof ExprSet |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, expr, typeof<Expr>, options)
+                    writer.WriteEndObject()
+                | FieldSet fieldName ->
+                    writer.WriteStartObject()
+                    nameof FieldSet |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, fieldName, typeof<string>, options)
+                    writer.WriteEndObject()
+                | ValueSet -> nameof ValueSet |> prefix |> wrap |> (fun v -> writer.WriteRawValue(v, true))
     type TestKindConverter() =
         inherit Serialization.JsonConverter<TestKind>()
         override this.CanConvert typ = typ = typeof<TestKind>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            ()
+            if canWrite writer then
+                let prefix postfix = $"{nameof TestKind}.{postfix}"
+                writer.WriteStartObject()
+                match value with
+                | TypeTest typ ->
+                    nameof TypeTest |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, typ, typeof<Fable.Type>, options)
+                | OptionTest isSome ->
+                    nameof OptionTest |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, isSome, typeof<bool>, options)
+                | ListTest isCons ->
+                    nameof ListTest |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, isCons, typeof<bool>, options)
+                | UnionCaseTest tag ->
+                    nameof UnionCaseTest |> prefix |> writer.WritePropertyName
+                    JsonSerializer.Serialize(writer, tag, typeof<int>, options)
+                writer.WriteEndObject()
     type ExtendedSetConverter() =
         inherit Serialization.JsonConverter<ExtendedSet>()
         override this.CanConvert typ = typ = typeof<ExtendedSet>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            ()
+            if canWrite writer then
+                writer.WriteRawValue("\"TODO_EXTENDEDSET\"", true)
     type UnresolvedExprConverter() =
         inherit Serialization.JsonConverter<UnresolvedExpr>()
         override this.CanConvert typ = typ = typeof<UnresolvedExpr>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            ()
+            if canWrite writer then
+                writer.WriteRawValue("\"TODO_UNRESOLVEDEXPR\"", true)
     type OperationKindConverter() =
         inherit Serialization.JsonConverter<OperationKind>()
         override this.CanConvert typ = typ = typeof<OperationKind>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            ()
+            if canWrite writer then
+                writer.WriteRawValue("\"TODO_OPERATIONKIND\"", true)
     type NumberKindConverter() =
         inherit Serialization.JsonConverter<NumberKind>()
         override this.CanConvert typ = typ = typeof<NumberKind>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            ()
+            if canWrite writer then
+                writer.WriteRawValue("\"TODO_NumberKindConverter\"", true)
     type RegexFlagConverter() =
         inherit Serialization.JsonConverter<RegexFlag>()
         override this.CanConvert typ = typ = typeof<RegexFlag>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            ()
+            if canWrite writer then
+                writer.WriteRawValue("\"TODO_RegexFlagConverter\"", true)
     type UnaryOperatorConverter() =
         inherit Serialization.JsonConverter<UnaryOperator>()
         override this.CanConvert typ = typ = typeof<UnaryOperator>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            ()
+            if canWrite writer then
+                writer.WriteRawValue("\"TODO_UnaryOperatorConverter\"", true)
     type BinaryOperatorConverter() =
         inherit Serialization.JsonConverter<BinaryOperator>()
         override this.CanConvert typ = typ = typeof<BinaryOperator>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            ()
+            if canWrite writer then
+                writer.WriteRawValue("\"TODO_BINARYOPERATOR\"")
     type LogicalOperatorConverter() =
         inherit Serialization.JsonConverter<LogicalOperator>()
         override this.CanConvert typ = typ = typeof<LogicalOperator>
-        override this.Read(_,_,_) = unbox null
+        override this.Read(_, _, _) = unbox null
         override this.Write(writer, value, options) =
-            ()
+            if canWrite writer then
+                writer.WriteRawValue("\"TODO_LOGICALOPERATOR\"")
 
     let options = JsonSerializerOptions(JsonSerializerDefaults.General)
-    options.Converters.Add (EntityPathConverter())
-    options.Converters.Add (MemberRefConverter())
-    options.Converters.Add (GeneratedMemberConverter())
-    options.Converters.Add (NumberInfoConverter())
-    options.Converters.Add (NumberValueConverter())
-    options.Converters.Add (ArrayKindConverter())
-    options.Converters.Add (ConstraintConverter())
-    options.Converters.Add (TypeConverter())
-    options.Converters.Add (ExprConverter())
-    options.Converters.Add (ValueKindConverter())
-    options.Converters.Add (TagSourceConverter())
-    options.Converters.Add (TagInfoConverter())
-    options.Converters.Add (ImportKindConverter())
-    options.Converters.Add (DeclarationConverter())
-    options.Converters.Add (NewArrayKindConverter())
-    options.Converters.Add (GetKindConverter())
-    options.Converters.Add (SetKindConverter())
-    options.Converters.Add (TestKindConverter())
-    options.Converters.Add (ExtendedSetConverter())
-    options.Converters.Add (UnresolvedExprConverter())
-    options.Converters.Add (OperationKindConverter())
-    options.Converters.Add (NumberKindConverter())
-    options.Converters.Add (RegexFlagConverter())
-    options.Converters.Add (UnaryOperatorConverter())
-    options.Converters.Add (BinaryOperatorConverter())
-    options.Converters.Add (LogicalOperatorConverter())
+    options.Converters.Add(EntityPathConverter())
+    options.Converters.Add(MemberRefConverter())
+    options.Converters.Add(GeneratedMemberConverter())
+    options.Converters.Add(NumberInfoConverter())
+    options.Converters.Add(NumberValueConverter())
+    options.Converters.Add(ArrayKindConverter())
+    options.Converters.Add(ConstraintConverter())
+    options.Converters.Add(TypeConverter())
+    options.Converters.Add(ExprConverter())
+    options.Converters.Add(ValueKindConverter())
+    options.Converters.Add(TagSourceConverter())
+    options.Converters.Add(TagInfoConverter())
+    options.Converters.Add(ImportKindConverter())
+    options.Converters.Add(DeclarationConverter())
+    options.Converters.Add(NewArrayKindConverter())
+    options.Converters.Add(GetKindConverter())
+    options.Converters.Add(SetKindConverter())
+    options.Converters.Add(TestKindConverter())
+    options.Converters.Add(ExtendedSetConverter())
+    options.Converters.Add(UnresolvedExprConverter())
+    options.Converters.Add(OperationKindConverter())
+    options.Converters.Add(NumberKindConverter())
+    options.Converters.Add(RegexFlagConverter())
+    options.Converters.Add(UnaryOperatorConverter())
+    options.Converters.Add(BinaryOperatorConverter())
+    options.Converters.Add(LogicalOperatorConverter())
+
+    // UN-UTILISED ATM
     /// ANSI Escape Sequences to colorize strings when directed to output.
     [<AutoOpen>]
     module private FColor =
         type private FColor = string
         /// When the output is not directed to console (ie directed to a file) then the escape sequence is not written
-        let private _fcolor value = if Console.IsOutputRedirected then "" else value
+        let private _fcolor value =
+            if Console.IsOutputRedirected then "" else value
 
         /// Applies Color to value only. Returns color to normal after.
         let colorize (color: FColor) (value: string) = $"{color}{value}{NORMAL}"
         // Presets
-        let NORMAL : FColor =_fcolor "\x1b[39m" // Normal
-        let REVERSE : FColor =_fcolor "\x1b[7m" // Inverts Foreground and Background colors
-        let NOREVERSE : FColor =_fcolor "\x1b[27m" // Reverts Foreground and Background colors
+        let NORMAL: FColor = _fcolor "\x1b[39m" // Normal
+        let REVERSE: FColor = _fcolor "\x1b[7m" // Inverts Foreground and Background colors
+        let NOREVERSE: FColor = _fcolor "\x1b[27m" // Reverts Foreground and Background colors
         // Colors
-        let RED : FColor =_fcolor "\x1b[91m"
-        let GREEN : FColor =_fcolor "\x1b[92m"
-        let YELLOW : FColor =_fcolor "\x1b[93m"
-        let BLUE : FColor =_fcolor "\x1b[94m"
-        let MAGENTA : FColor =_fcolor "\x1b[95m"
-        let CYAN : FColor =_fcolor "\x1b[96m"
-        let GREY : FColor =_fcolor "\x1b[97m"
+        let RED: FColor = _fcolor "\x1b[91m"
+        let GREEN: FColor = _fcolor "\x1b[92m"
+        let YELLOW: FColor = _fcolor "\x1b[93m"
+        let BLUE: FColor = _fcolor "\x1b[94m"
+        let MAGENTA: FColor = _fcolor "\x1b[95m"
+        let CYAN: FColor = _fcolor "\x1b[96m"
+        let GREY: FColor = _fcolor "\x1b[97m"
         // Formatting
-        let BOLD : FColor =_fcolor "\x1b[1m" // Intense
-        let NOBOLD : FColor =_fcolor "\x1b[22m" // Normal intensity
-        let UNDERLINE : FColor =_fcolor "\x1b[4m" // Underlined
-        let NOUNDERLINE : FColor =_fcolor "\x1b[24m" // Remove any underline
-    type PrettyPrinter =
-        static member print(value: 'T): string = JsonSerializer.Serialize(value, options)
+        let BOLD: FColor = _fcolor "\x1b[1m" // Intense
+        let NOBOLD: FColor = _fcolor "\x1b[22m" // Normal intensity
+        let UNDERLINE: FColor = _fcolor "\x1b[4m" // Underlined
+        let NOUNDERLINE: FColor = _fcolor "\x1b[24m" // Remove any underline
+
+// Public API point for plugin printing AST to string
+type PrettyPrinter =
+    static member print(value: 'T) : string =
+        JsonSerializer.Serialize(value, PrettyPrint.options)

--- a/src/Oxpecker.Solid.FablePlugin/PrettyPrint.fs
+++ b/src/Oxpecker.Solid.FablePlugin/PrettyPrint.fs
@@ -1,973 +1,290 @@
-﻿namespace Oxpecker.Solid.FablePlugin
-
-// Contains logic to enable JSON conversion and printing of AST to assist
-// in plugin development and debugging.
-//
-// The intention is to provide JSON that can be viewed in a tree structure with any
-// compatible JSON viewing tool
-//
-// There are several CommandLine defines that can be provided to enable and
-// modify this behaviour.
-// The printing of the AST in JSON has a depth limit to provide the relevant depth
-// of information on nodes that are being transformed.
-// Otherwise, you would want to redirect your console output to a file.
-// The tracers, when enabled, emit on most transformations and transitions in the plugin logic,
-// so the output very quickly can become verbose
-//
-// =======
-// DEFINES
-// =======
-// OXPECKER_SOLID_MINIMAL    //* No Json printing, just operation flow is printed
-// OXPECKER_SOLID_DEBUG      //* Max depth of 4 - default
-// OXPECKER_SOLID_DEBUG_1    //* Max depth of 1
-// ''  ''    ''  ''     [n]  //* Max depth of n
-// OXPECKER_SOLID_TRACE      //* No max depth.
-//
-// OXPECKER_SOLID_MINIMAL                               //* This combo will cause the json to be slim.
-// && (OXPECKER_SOLID_DEBUG || OXPECKER_SOLID_TRACE)    //  ie we replace things like paths with nulls
-//
-// =======
-// USAGE
-// =======
-// fable --define OXPECKER_SOLID_DEBUG
+﻿namespace rec Fable.Plugin.Tracer
 
 open System
+open System.Runtime.InteropServices
+open System.Runtime.CompilerServices
+open System.Text.Json // included post .net7 or 8
 open Fable.AST
 open Fable.AST.Fable
-open Types
-open System.Text.Json
+open Oxpecker.Solid.FablePlugin
 
 [<AutoOpen>]
-module private CompilerDirectives =
-    // Converters can use a simple one liner at the beginning of their Write to see if
-    // 1) they can write (if some debug mode is on; although this wouldnt be reached in that case
-    // 2) the max depth has been reached as per some other definition or directive
-    let private maxDepth: unit -> int = PluginConfiguration.Depth
-    let mutable private _canWrite = fun (writer: Utf8JsonWriter) -> false
-    _canWrite <-
-        fun writer ->
-            if maxDepth() > 0 && writer.CurrentDepth > maxDepth() then
-                writer.WriteRawValue($"\"MAX_DEPTH\"", true)
-                false
-            else
-                true
-    let canWrite = _canWrite
-    let simplify = PluginConfiguration.Slim
-module private rec PrettyPrint =
-    (*  The Converters are all written the same.
-    The Write logic is wrapped in an `if` statement. It checks against the current depth
-    of the writer with whatever Compiler Directives are enabled to determine if it should
-    proceed. If not, it writes "MAX_DEPTH".
+module TracerConfiguration =
+    [<Literal>]
+    let private minimal = "MINIMAL"
+    [<Literal>]
+    let private debug = "DEBUG"
+    [<Literal>]
+    let private trace = "TRACE"
+    [<Literal>]
+    let private file = "FILE"
+    /// Extracts the num arg appended to the debug definition, if it is parseable, in an option.
+    let private debugDepth (input: string) : int option =
+        if input.StartsWith("DEBUG_") then Some input else None
+        |> Option.map _.ToCharArray()
+        |> Option.map(Array.filter Char.IsDigit)
+        |> Option.map String.Concat
+        |> Option.map int
+    /// Convenience active recognizer that matches against an input list of strings, and outputs the first item, that matches the given value/string
+    let (|Contains|_|) (value: string) (input: string list) = input |> List.tryFind((=) value)
+    /// Convenience active recognizer that matches against an input list of strings, and outputs the first item, that starts with the given value/string
+    let (|ContainsSomethingStartingWith|_|) (value: string) (input: string list) =
+        input |> List.tryFind(_.StartsWith(value))
+    /// <summary>
+    /// Setting helper for the Fable Plugin Tracer.
+    /// </summary>
+    /// <example>
+    /// To configure and enable the tracer, you need to provide a `Fable.PluginHelper` object
+    /// (which is found in one of the transform methods) in the following way:
+    /// <code>
+    /// Settings.configure pluginHelper
+    /// </code>
+    /// <br/>
+    /// To set the prefix for the fable defines that would active the tracer:
+    /// <code>
+    /// Settings.pluginName "OXPECKER_SOLID"
+    /// </code>
+    /// Which translates to usage such as
+    /// <code>
+    /// fable --define OXPECKER_SOLID_DEBUG
+    /// </code>
+    /// </example>
+    [<RequireQualifiedAccess>]
+    type Settings() =
+        static let mutable PluginName = "PLUGIN_TRACER"
+        static let mutable Verbose = false
+        static let mutable Depth = 4
+        static let mutable Jsonify = true
+        static let mutable ToFile = false
+        static let mutable FileName = ""
+        static let mutable FileStream = null
+        static let mutable StreamWriter = null
+        static let StandardOutput =
+            let this = new IO.StreamWriter(Console.OpenStandardOutput()) in
+            this.AutoFlush <- true
+            this
+        static let mutable options = JsonSerializerOptions(JsonSerializerDefaults.General)
+        static member configure (pluginName: string) (helper: Fable.PluginHelper) =
+            PluginName <- pluginName
+            if
+                helper.Options.Define
+                |> List.exists(fun definition -> definition.StartsWith $"{PluginName}_")
+            then
+                Verbose <- true
+                let definitions =
+                    helper.Options.Define
+                    |> List.filter _.StartsWith($"{PluginName}_")
+                    |> List.map _.Substring($"{PluginName}_" |> _.Length)
+                let rec enable input =
+                    match input with
+                    | Contains file _ ->
+                        ToFile <- true
+                        FileName <- $"{PluginName}_{DateTime.Now.ToFileTime()}.txt"
+                        FileStream <- new IO.FileStream(FileName, IO.FileMode.Append)
+                        StreamWriter <- new IO.StreamWriter(FileStream)
+                        StreamWriter.AutoFlush <- true
+                        input |> List.filter((<>) file) |> enable
+                    | Contains minimal _ & ContainsSomethingStartingWith debug recurse
+                    | Contains minimal _ & Contains trace recurse ->
+                        // TODO - the minimal flag combined with debug/trace is supposed to slim down the JSON output
+                        Jsonify <- false
+                        enable [ recurse ]
+                    | Contains minimal _ -> Jsonify <- false
+                    | ContainsSomethingStartingWith debug debugDefine ->
+                        match debugDepth debugDefine with
+                        | Some i -> Depth <- i
+                        | None -> ()
+                    | Contains trace _ -> Depth <- 0
+                    | _ -> ()
+                enable definitions
+        static member verbose() = Verbose
+        static member verbose value = Verbose <- value
+        static member depth() = Depth
+        static member depth value = Depth <- value
+        static member jsonify() = Jsonify
+        static member jsonify value = Jsonify <- value
+        static member toFile() = ToFile
+        static member toFile value = ToFile <- value
+        static member canPipe() =
+            if ToFile then
+                Console.SetOut StreamWriter
+        static member closePipe() =
+            if ToFile then
+                Console.SetOut StandardOutput
+        static member converterOptions() = options
+        static member addConverter converter = options.Converters.Add converter
+        static member registerConverter<'T>() =
+            JsonConverters.UnionConverter<'T>() |> Settings.addConverter
+type Tracer =
+    static member ping
+        (
+            [<Optional; DefaultParameterValue("")>] message: string,
+            [<CallerMemberName; Optional; DefaultParameterValue("")>] memberName: string,
+            [<CallerFilePath; Optional; DefaultParameterValue("")>] path: string,
+            [<CallerLineNumber; Optional; DefaultParameterValue(0)>] line: int
+        ) =
+        let print () =
+            Console.Write "                                     "
+            Console.Write $"{memberName, -20}"
+            Console.ResetColor()
+            Console.WriteLine $"{message} ({path}:{line})"
 
-  * We only have to provide converters for the Discriminated Unions (DUs).
-    Whenever writing JSON output, you should assume you are writing in the 'value' position.
-    ie. Wrap all non-value output in an object or array.
+        if Settings.verbose() then
+            print()
+            if Settings.toFile() then
+                Settings.canPipe()
+                print()
+                Settings.closePipe()
 
-  * Remember the output is not supposed to be decodable, or accurately reflect the underlying
-    types.
+type Tracer<'T> = {
+    Value: 'T
+    Guid: Guid
+    ConsoleColor: ConsoleColor
+} with
+    member private this.emit
+        (
+            message: string,
+            memberName: string,
+            path: string,
+            line: int,
+            [<Optional; DefaultParameterValue(true)>] emitJson: bool
+        ) =
+        let print () =
+            Console.ForegroundColor <- this.ConsoleColor
+            Console.Write $"{this.Guid} "
+            Console.ForegroundColor <- ConsoleColor.Gray
+            Console.Write $"{memberName, -20}"
+            Console.ResetColor()
+            Console.WriteLine $"{message} ({path}:{line})"
+        if Settings.verbose() then
+            print()
+            if Settings.jsonify() && emitJson then
+                if Settings.toFile() then
+                    Settings.canPipe()
+                    print()
+                    Console.WriteLine $"{PrettyPrinter.print this.Value}"
+                    Settings.closePipe()
+                else
+                    Console.WriteLine $"{PrettyPrinter.print this.Value}"
+    member this.trace
+        (
+            [<Optional; DefaultParameterValue("")>] message: string,
+            [<CallerMemberName; Optional; DefaultParameterValue("")>] memberName: string,
+            [<CallerFilePath; Optional; DefaultParameterValue("")>] path: string,
+            [<CallerLineNumber; Optional; DefaultParameterValue(0)>] line: int
+        ) =
+        this.emit(message, memberName, path, line)
+        this
+    member this.ping
+        (
+            [<Optional; DefaultParameterValue("")>] message: string,
+            [<CallerMemberName; Optional; DefaultParameterValue("")>] memberName: string,
+            [<CallerFilePath; Optional; DefaultParameterValue("")>] path: string,
+            [<CallerLineNumber; Optional; DefaultParameterValue(0)>] line: int
+        ) =
+        this.emit(message, memberName, path, line)
+module Tracer =
+    let private random = Random()
 
-  * DUs should have their name embedded in the object value. The PropertyName should be the
-    DU type wrapped in __, and the value would be the DU Value.
-    GOOD_OUTPUT: {"__EntityPath__":"SourcePath",...:...}
+    let inline private _create value guid consoleColor = {
+        Value = value
+        Guid = guid
+        ConsoleColor = consoleColor
+    }
 
-  * Prepend all DUs choices with the root type name.
-    BAD_OUTPUT: {"SourcePath":"value"}
-    GOOD_OUTPUT: {"EntityPath.SourcePath":"value"}
+    let empty = _create () Guid.Empty ConsoleColor.Black
+    let create value =
+        if Settings.verbose() then
+            random.Next(15) |> enum<ConsoleColor> |> _create value (Guid.NewGuid())
+        else
+            _create value Guid.Empty ConsoleColor.Black
 
-  * If DU tuples are named, it is valuable information on the context of the values.
-    Why wrap them in an array?
-    Wrap them in an anonymous object (with the fields named according to the tuple) and use
-    JsonSerializer. Or, write the object with the field/values set by hand.
-    Obviously simple/single value/non-tupled DUs don't have to do this.
-    BAD_OUTPUT: {"Constraint.HasMember":[{...}, false]}
-    GOOD_OUTPUT: {"Constraint.HasMember":{"name":{...}, "isStatic":false}}                      *)
-    let wrapUnionType str = $"__{str}__"
-    type EntityPathConverter() =
-        inherit Serialization.JsonConverter<EntityPath>()
-        override this.CanConvert typ = typ = typeof<EntityPath>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if simplify() then
-                nameof EntityPath |> wrapUnionType |> writer.WriteStringValue
-            elif canWrite writer then
-                let prefix postfix = $"{nameof EntityPath}.{postfix}"
-                writer.WriteStartObject()
-                match value with
-                | SourcePath s -> writer.WriteString(prefix(nameof SourcePath), s)
-                | AssemblyPath s -> writer.WriteString(prefix(nameof AssemblyPath), s)
-                | CoreAssemblyName s -> writer.WriteString(prefix(nameof CoreAssemblyName), s)
-                | PrecompiledLib(sourcePath, assemblyPath) ->
-                    writer.WriteString(
-                        prefix(nameof PrecompiledLib),
-                        JsonSerializer.Serialize {|
-                            sourcePath = sourcePath
-                            assemblyPath = assemblyPath
-                        |}
-                    )
-                writer.WriteEndObject()
-    type MemberRefConverter() =
-        inherit Serialization.JsonConverter<MemberRef>()
-        override this.CanConvert typ = typ = typeof<MemberRef>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                let prefix postfix = $"{nameof MemberRef}.{postfix}"
-                writer.WriteStartObject()
-                match value with
-                | MemberRef(declaringEntity, info) ->
-                    let inp = {|
-                        declaringEntity = declaringEntity
-                        info = info
-                    |}
-                    writer.WritePropertyName(prefix(nameof MemberRef))
-                    JsonSerializer.Serialize(writer, inp, inp.GetType(), options)
-                | GeneratedMemberRef generatedMember ->
-                    nameof GeneratedMemberRef |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, generatedMember, generatedMember.GetType(), options)
-                writer.WriteEndObject()
-    type GeneratedMemberConverter() =
-        inherit Serialization.JsonConverter<GeneratedMember>()
-        override this.CanConvert typ = typ = typeof<GeneratedMember>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                let prefix postfix = $"{nameof GeneratedMember}.{postfix}"
-                match value with
-                | GeneratedFunction info ->
-                    let object = {| GeneratedFunction = info |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | GeneratedValue info ->
-                    let object = {| GeneratedValue = info |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | GeneratedGetter info ->
-                    let object = {| GeneratedGetter = info |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | GeneratedSetter info ->
-                    let object = {| GeneratedSetter = info |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-    type NumberInfoConverter() =
-        inherit Serialization.JsonConverter<NumberInfo>()
-        override this.CanConvert typ = typ = typeof<NumberInfo>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                let prefix postfix = $"{nameof NumberInfo}.{postfix}"
-                writer.WriteStartObject()
-                match value with
-                | NumberInfo.Empty -> nameof NumberInfo.Empty |> prefix |> writer.WriteNull
-                | NumberInfo.IsMeasure fullname ->
-                    nameof NumberInfo.IsMeasure
-                    |> prefix
-                    |> fun prop -> writer.WriteString(prop, fullname)
-                | NumberInfo.IsEnum ent ->
-                    nameof NumberInfo.IsEnum |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, ent, ent.GetType(), options)
-                writer.WriteEndObject()
-    type NumberValueConverter() =
-        inherit Serialization.JsonConverter<NumberValue>()
-        override this.CanConvert typ = typ = typeof<NumberValue>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                match value with
-                | NumberValue.Int8 b -> JsonSerializer.Serialize(writer, b, typeof<sbyte>, options)
-                | NumberValue.UInt8 b -> JsonSerializer.Serialize(writer, b, typeof<byte>, options)
-                | NumberValue.Int16 s -> JsonSerializer.Serialize(writer, s, typeof<int16>, options)
-                | NumberValue.UInt16 s -> JsonSerializer.Serialize(writer, s, typeof<uint16>, options)
-                | NumberValue.Int32 i -> JsonSerializer.Serialize(writer, i, typeof<int32>, options)
-                | NumberValue.UInt32 i -> JsonSerializer.Serialize(writer, i, typeof<uint32>, options)
-                | NumberValue.Int64 int64 -> JsonSerializer.Serialize(writer, int64, int64.GetType(), options)
-                | NumberValue.UInt64 uInt64 -> JsonSerializer.Serialize(writer, uInt64, uInt64.GetType(), options)
-                | NumberValue.Int128(upper, lower) -> $"{upper}{lower}" |> fun v -> writer.WriteRawValue(v, true)
-                | NumberValue.UInt128(upper, lower) -> $"{upper}{lower}" |> fun v -> writer.WriteRawValue(v, true)
-                | NumberValue.BigInt bigInteger ->
-                    JsonSerializer.Serialize(writer, bigInteger, bigInteger.GetType(), options)
-                | NumberValue.NativeInt intPtr -> JsonSerializer.Serialize(writer, intPtr, intPtr.GetType(), options)
-                | NumberValue.UNativeInt uIntPtr ->
-                    JsonSerializer.Serialize(writer, uIntPtr, uIntPtr.GetType(), options)
-                | NumberValue.Float16 f -> JsonSerializer.Serialize(writer, f, f.GetType(), options)
-                | NumberValue.Float32 f -> JsonSerializer.Serialize(writer, f, f.GetType(), options)
-                | NumberValue.Float64 f -> JsonSerializer.Serialize(writer, f, f.GetType(), options)
-                | NumberValue.Decimal decimal -> JsonSerializer.Serialize(writer, decimal, decimal.GetType(), options)
-    type ArrayKindConverter() =
-        inherit Serialization.JsonConverter<ArrayKind>()
-        override this.CanConvert typ = typ = typeof<ArrayKind>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                writer.WriteStartObject()
-                match value with
-                | ResizeArray -> nameof ResizeArray
-                | MutableArray -> nameof MutableArray
-                | ImmutableArray -> nameof ImmutableArray
-                |> fun value -> writer.WriteString(nameof ArrayKind, value)
-                writer.WriteEndObject()
-    type ConstraintConverter() =
-        inherit Serialization.JsonConverter<Constraint>()
-        override this.CanConvert typ = typ = typeof<Constraint>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                let wrap input = $"\"{input}\""
-                writer.WriteStartObject()
-                match value with
-                | Constraint.HasMember(name, isStatic) ->
-                    writer.WritePropertyName $"{nameof Constraint}.{nameof Constraint.HasMember}"
-                    let object = {| name = name; isStatic = isStatic |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | Constraint.CoercesTo target ->
-                    writer.WritePropertyName $"{nameof Constraint}.{nameof Constraint.CoercesTo}"
-                    JsonSerializer.Serialize(writer, target, typeof<Fable.Type>, options)
-                | Constraint.IsNullable ->
-                    let object = wrap $"{nameof Constraint}.{nameof Constraint.IsNullable}"
-                    writer.WriteRawValue(object, true)
-                | Constraint.IsValueType ->
-                    let object = wrap $"{nameof Constraint}.{nameof Constraint.IsValueType}"
-                    writer.WriteRawValue(object, true)
-                | Constraint.IsReferenceType ->
-                    let object = wrap $"{nameof Constraint}.{nameof Constraint.IsReferenceType}"
-                    writer.WriteRawValue(object, true)
-                | Constraint.HasDefaultConstructor ->
-                    let object = wrap $"{nameof Constraint}.{nameof Constraint.HasDefaultConstructor}"
-                    writer.WriteRawValue(object, true)
-                | Constraint.HasComparison ->
-                    let object = wrap $"{nameof Constraint}.{nameof Constraint.HasComparison}"
-                    writer.WriteRawValue(object, true)
-                | Constraint.HasEquality ->
-                    let object = wrap $"{nameof Constraint}.{nameof Constraint.HasEquality}"
-                    writer.WriteRawValue(object, true)
-                | Constraint.IsUnmanaged ->
-                    let object = wrap $"{nameof Constraint}.{nameof Constraint.IsUnmanaged}"
-                    writer.WriteRawValue(object, true)
-                | Constraint.IsEnum ->
-                    let object = wrap $"{nameof Constraint}.{nameof Constraint.IsEnum}"
-                    writer.WriteRawValue(object, true)
-                writer.WriteEndObject()
-    type TypeConverter() =
-        inherit Serialization.JsonConverter<Fable.Type>()
-        override this.CanConvert typ = typ = typeof<Fable.Type>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                let wrap input = $"\"{input}\""
-                let prefix postfix = $"{nameof Fable.Type}.{postfix}"
-                match value with
-                | Type.Measure fullname -> writer.WriteString(prefix(nameof Measure), fullname)
-                | Type.MetaType ->
-                    let object = (nameof MetaType) |> prefix |> wrap in writer.WriteRawValue(object, true)
-                | Type.Any -> let object = (nameof Any) |> prefix |> wrap in writer.WriteRawValue(object, true)
-                | Type.Unit -> let object = (nameof Unit) |> prefix |> wrap in writer.WriteRawValue(object, true)
-                | Type.Boolean -> let object = (nameof Boolean) |> prefix |> wrap in writer.WriteRawValue(object, true)
-                | Type.Char -> let object = (nameof Char) |> prefix |> wrap in writer.WriteRawValue(object, true)
-                | Type.String -> let object = (nameof String) |> prefix |> wrap in writer.WriteRawValue(object, true)
-                | Type.Regex -> let object = (nameof Regex) |> prefix |> wrap in writer.WriteRawValue(object, true)
-                | Type.Number(kind, info) ->
-                    writer.WriteStartObject()
-                    writer.WritePropertyName(prefix(nameof Number))
-                    let object = {| kind = kind; info = info |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                    writer.WriteEndObject()
-                | Type.Option(genericArg, isStruct) ->
-                    writer.WriteStartObject()
-                    writer.WritePropertyName(prefix(nameof Option))
-                    let object = {|
-                        genericArg = genericArg
-                        isStruct = isStruct
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                    writer.WriteEndObject()
-                | Type.Tuple(genericArgs, isStruct) ->
-                    writer.WriteStartObject()
-                    writer.WritePropertyName(prefix(nameof Tuple))
-                    let object = {|
-                        genericArgs = genericArgs
-                        isStruct = isStruct
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                    writer.WriteEndObject()
-                | Type.Array(genericArg, kind) ->
-                    writer.WriteStartObject()
-                    writer.WritePropertyName(prefix(nameof Array))
-                    let object = {|
-                        genericArg = genericArg
-                        kind = kind
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                    writer.WriteEndObject()
-                | Type.List genericArg ->
-                    writer.WriteStartObject()
-                    writer.WritePropertyName(prefix(nameof List))
-                    let object = {| genericArg = genericArg |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                    writer.WriteEndObject()
-                | Type.LambdaType(argType, returnType) ->
-                    writer.WriteStartObject()
-                    writer.WritePropertyName(prefix(nameof LambdaType))
-                    let object = {|
-                        argType = argType
-                        returnType = returnType
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                    writer.WriteEndObject()
-                | Type.DelegateType(argTypes, returnType) ->
-                    writer.WriteStartObject()
-                    writer.WritePropertyName(prefix(nameof DelegateType))
-                    let object = {|
-                        argTypes = argTypes
-                        returnType = returnType
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                    writer.WriteEndObject()
-                | Type.GenericParam(name, isMeasure, constraints) ->
-                    writer.WriteStartObject()
-                    writer.WritePropertyName(prefix(nameof GenericParam))
-                    let object = {|
-                        name = name
-                        isMeasure = isMeasure
-                        constraints = constraints
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                    writer.WriteEndObject()
-                | Type.DeclaredType(rref, genericArgs) ->
-                    writer.WriteStartObject()
-                    writer.WritePropertyName(prefix(nameof DeclaredType))
-                    let object = {|
-                        rref = rref
-                        genericArgs = genericArgs
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                    writer.WriteEndObject()
-                | Type.AnonymousRecordType(fieldNames, genericArgs, isStruct) ->
-                    writer.WriteStartObject()
-                    writer.WritePropertyName(prefix(nameof AnonymousRecordType))
-                    let object = {|
-                        fieldNames = fieldNames
-                        genericArgs = genericArgs
-                        isStruct = isStruct
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                    writer.WriteEndObject()
-    type ExprConverter() =
-        inherit Serialization.JsonConverter<Expr>()
-        override this.CanConvert typ = typ = typeof<Expr>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                let prefix postfix = $"{nameof Expr}.{postfix}"
-                writer.WriteStartObject()
-                match value with
-                | IdentExpr ident ->
-                    writer.WritePropertyName(prefix(nameof IdentExpr))
-                    JsonSerializer.Serialize(writer, ident, ident.GetType(), options)
-                | Value(kind, range) ->
-                    writer.WritePropertyName(prefix(nameof Value))
-                    let object = {| kind = kind; range = range |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | Lambda(arg, body, name) ->
-                    writer.WritePropertyName(prefix(nameof Lambda))
-                    let object = {|
-                        arg = arg
-                        body = body
-                        name = name
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | Delegate(args, body, name, tags) ->
-                    writer.WritePropertyName(prefix(nameof Delegate))
-                    let object = {|
-                        args = args
-                        body = body
-                        name = name
-                        tags = tags
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | ObjectExpr(members, typ, baseCall) ->
-                    writer.WritePropertyName(prefix(nameof ObjectExpr))
-                    let object = {|
-                        members = members
-                        ``type`` = typ
-                        baseCall = baseCall
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | TypeCast(expr, typ) ->
-                    writer.WritePropertyName(prefix(nameof TypeCast))
-                    let object = {| expr = expr; ``type`` = typ |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | Test(expr, kind, range) ->
-                    writer.WritePropertyName(prefix(nameof Test))
-                    let object = {|
-                        expr = expr
-                        kind = kind
-                        range = range
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | Call(callee, info, typ, range) ->
-                    writer.WritePropertyName(prefix(nameof Call))
-                    let object = {|
-                        callee = callee
-                        info = info
-                        ``type`` = typ
-                        range = range
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | CurriedApply(applied, args, typ, range) ->
-                    writer.WritePropertyName(prefix(nameof CurriedApply))
-                    let object = {|
-                        applied = applied
-                        args = args
-                        ``type`` = typ
-                        range = range
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | Operation(kind, tags, typ, range) ->
-                    writer.WritePropertyName(prefix(nameof Operation))
-                    let object = {|
-                        kind = kind
-                        tags = tags
-                        ``type`` = typ
-                        range = range
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | Import(info, typ, range) ->
-                    writer.WritePropertyName(prefix(nameof Import))
-                    let object = {| info = info; range = range |}
-                    writer.WriteStartObject()
-                    writer.WritePropertyName "info"
-                    JsonSerializer.Serialize(writer, info, typeof<ImportInfo>, options)
-                    writer.WritePropertyName "type"
-                    JsonSerializer.Serialize(writer, typ, typeof<Fable.Type>, options)
-                    writer.WritePropertyName "range"
-                    JsonSerializer.Serialize(writer, range, typeof<SourceLocation option>, options)
-                    writer.WriteEndObject()
-                | Emit(info, typ, range) ->
-                    writer.WritePropertyName(prefix(nameof Emit))
-                    let object = {|
-                        info = info
-                        ``type`` = typ
-                        range = range
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | DecisionTree(expr, targets) ->
-                    writer.WritePropertyName(prefix(nameof DecisionTree))
-                    let object = {| expr = expr; targets = targets |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | DecisionTreeSuccess(targetIndex, boundValues, typ) ->
-                    writer.WritePropertyName(prefix(nameof DecisionTreeSuccess))
-                    let object = {|
-                        targetIndex = targetIndex
-                        boundValues = boundValues
-                        ``type`` = typ
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | Let(ident, value, body) ->
-                    writer.WritePropertyName(prefix(nameof Let))
-                    let object = {|
-                        ident = ident
-                        value = value
-                        body = body
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | LetRec(bindings, body) ->
-                    writer.WritePropertyName(prefix(nameof LetRec))
-                    let object = {| bindings = bindings; body = body |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | Get(expr, kind, typ, range) ->
-                    writer.WritePropertyName(prefix(nameof Get))
-                    let object = {|
-                        expr = expr
-                        kind = kind
-                        ``type`` = typ
-                        range = range
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | Set(expr, kind, typ, value, range) ->
-                    writer.WritePropertyName(prefix(nameof Set))
-                    let object = {|
-                        expr = expr
-                        kind = kind
-                        ``type`` = typ
-                        value = value
-                        range = range
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | Sequential exprs ->
-                    writer.WritePropertyName(prefix(nameof Sequential))
-                    let object = exprs
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | WhileLoop(guard, body, range) ->
-                    writer.WritePropertyName(prefix(nameof WhileLoop))
-                    let object = {|
-                        guard = guard
-                        body = body
-                        range = range
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | ForLoop(ident, start, limit, body, isUp, range) ->
-                    writer.WritePropertyName(prefix(nameof ForLoop))
-                    let object = {|
-                        ident = ident
-                        start = start
-                        limit = limit
-                        body = body
-                        isUp = isUp
-                        range = range
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | TryCatch(body, catch, finalizer, range) ->
-                    writer.WritePropertyName(prefix(nameof TryCatch))
-                    let object = {|
-                        body = body
-                        catch = catch
-                        finalizer = finalizer
-                        range = range
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | IfThenElse(guardExpr, thenExpr, elseExpr, range) ->
-                    writer.WritePropertyName(prefix(nameof IfThenElse))
-                    let object = {|
-                        guardExpr = guardExpr
-                        thenExpr = thenExpr
-                        elseExpr = elseExpr
-                        range = range
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | Unresolved(expr, typ, range) ->
-                    writer.WritePropertyName(prefix(nameof Unresolved))
-                    let object = {|
-                        expr = expr
-                        ``type`` = typ
-                        range = range
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | Extended(expr, range) ->
-                    writer.WritePropertyName(prefix(nameof Extended))
-                    let object = {| expr = expr; range = range |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                writer.WriteEndObject()
-    type ValueKindConverter() =
-        inherit Serialization.JsonConverter<ValueKind>()
-        override this.CanConvert typ = typ = typeof<ValueKind>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                let prefix postfix = $"{nameof ValueKind}.{postfix}"
-                let wrap input = $"\"{input}\""
-                writer.WriteStartObject()
-                match value with
-                | ThisValue typ ->
-                    nameof ThisValue |> prefix |> wrap |> writer.WritePropertyName
-                    let object = typ
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | BaseValue(boundIdent, typ) ->
-                    nameof BaseValue |> prefix |> wrap |> writer.WritePropertyName
-                    let object = {|
-                        boundIdent = boundIdent
-                        ``type`` = typ
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | TypeInfo(typ, tags) ->
-                    nameof TypeInfo |> prefix |> wrap |> writer.WritePropertyName
-                    let object = {| ``type`` = typ; tags = tags |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | Null typ ->
-                    nameof Null |> prefix |> wrap |> writer.WritePropertyName
-                    let object = typ
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | UnitConstant ->
-                    nameof UnitConstant |> prefix |> wrap |> writer.WritePropertyName
-                    let object = ()
-                    JsonSerializer.Serialize(writer, object, typeof<unit>, options)
-                | BoolConstant value ->
-                    nameof BoolConstant |> prefix |> wrap |> writer.WritePropertyName
-                    let object = value
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | CharConstant value ->
-                    nameof CharConstant |> prefix |> wrap |> writer.WritePropertyName
-                    let object = value
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | StringConstant value ->
-                    nameof StringConstant |> prefix |> wrap |> writer.WritePropertyName
-                    let object = value
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | StringTemplate(tag, parts, values) ->
-                    nameof StringTemplate |> prefix |> wrap |> writer.WritePropertyName
-                    let object = {|
-                        tag = tag
-                        parts = parts
-                        values = values
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | NumberConstant(value, info) ->
-                    nameof NumberConstant |> prefix |> wrap |> writer.WritePropertyName
-                    let object = {| value = value; info = info |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | RegexConstant(source, flags) ->
-                    nameof RegexConstant |> prefix |> wrap |> writer.WritePropertyName
-                    let object = {| source = source; flags = flags |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | NewOption(value, typ, isStruct) ->
-                    nameof NewOption |> prefix |> wrap |> writer.WritePropertyName
-                    let object = {|
-                        value = value
-                        ``type`` = typ
-                        isStruct = isStruct
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | NewArray(newKind, typ, kind) ->
-                    nameof NewArray |> prefix |> wrap |> writer.WritePropertyName
-                    let object = {|
-                        newKind = newKind
-                        ``type`` = typ
-                        kind = kind
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | NewList(headAndTail, typ) ->
-                    nameof NewList |> prefix |> wrap |> writer.WritePropertyName
-                    let object = {|
-                        headAndTail = headAndTail
-                        ``type`` = typ
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | NewTuple(values, isStruct) ->
-                    nameof NewTuple |> prefix |> wrap |> writer.WritePropertyName
-                    let object = {|
-                        values = values
-                        isStruct = isStruct
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | NewRecord(values, rref, genArgs) ->
-                    nameof NewRecord |> prefix |> wrap |> writer.WritePropertyName
-                    let object = {|
-                        values = values
-                        rref = rref
-                        genArgs = genArgs
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | NewAnonymousRecord(values, fieldNames, genArgs, isStruct) ->
-                    nameof NewAnonymousRecord |> prefix |> wrap |> writer.WritePropertyName
-                    let object = {|
-                        values = values
-                        fieldNames = fieldNames
-                        genArgs = genArgs
-                        isStruct = isStruct
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | NewUnion(values, tag, rref, genArgs) ->
-                    nameof NewUnion |> prefix |> wrap |> writer.WritePropertyName
-                    let object = {|
-                        values = values
-                        tag = tag
-                        rref = rref
-                        genArgs = genArgs
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                writer.WriteEndObject()
-    type TagSourceConverter() =
-        inherit Serialization.JsonConverter<TagSource>()
-        override this.CanConvert typ = typ = typeof<TagSource>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                let prefix postfix = $"{nameof TagSource}.{postfix}"
-                writer.WriteStartObject()
-                match value with
-                | AutoImport tagName -> writer.WriteString(prefix(nameof AutoImport), tagName)
-                | LibraryImport imp ->
-                    writer.WritePropertyName(prefix(nameof LibraryImport))
-                    JsonSerializer.Serialize(writer, imp, typeof<Expr>, options)
-                writer.WriteEndObject()
-    type TagInfoConverter() =
-        inherit Serialization.JsonConverter<TagInfo>()
-        override this.CanConvert typ = typ = typeof<TagInfo>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                let prefix postfix = $"{nameof TagInfo}.{postfix}"
-                writer.WriteStartObject()
-                match value with
-                | WithChildren(tagName, propsAndChildren, range) ->
-                    nameof WithChildren |> prefix |> writer.WritePropertyName
-                    let object = {|
-                        tagName = tagName
-                        propsAndChildren = propsAndChildren
-                        range = range
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | NoChildren(tagName, props, range) ->
-                    nameof NoChildren |> prefix |> writer.WritePropertyName
-                    let object = {|
-                        tagName = tagName
-                        props = props
-                        range = range
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                | Combined(tagName, props, propsAndChildren, range) ->
-                    nameof Combined |> prefix |> writer.WritePropertyName
-                    let object = {|
-                        tagName = tagName
-                        props = props
-                        propsAndChildren = propsAndChildren
-                        range = range
-                    |}
-                    JsonSerializer.Serialize(writer, object, object.GetType(), options)
-                writer.WriteEndObject()
-    type ImportKindConverter() =
-        inherit Serialization.JsonConverter<ImportKind>()
-        override this.CanConvert typ = typ = typeof<ImportKind>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                let prefix postfix = $"{nameof ImportKind}.{postfix}"
-                let wrap input = $"\"{input}\""
-                match value with
-                | UserImport isInline -> nameof UserImport |> prefix |> wrap |> (fun v -> writer.WriteRawValue(v, true))
-                | ImportKind.LibraryImport info ->
-                    writer.WriteStartObject()
-                    nameof ImportKind.LibraryImport |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, info, typeof<LibraryImportInfo>, options)
-                    writer.WriteEndObject()
-                | MemberImport memberRef ->
-                    writer.WriteStartObject()
-                    nameof MemberImport |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, memberRef, typeof<MemberRef>, options)
-                    writer.WriteEndObject()
-                | ClassImport entRef ->
-                    writer.WriteStartObject()
-                    nameof ClassImport |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, entRef, typeof<EntityRef>, options)
-                    writer.WriteEndObject()
-    type DeclarationConverter() =
-        inherit Serialization.JsonConverter<Declaration>()
-        override this.CanConvert typ = typ = typeof<Declaration>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                let prefix postfix = $"{nameof Declaration}.{postfix}"
-                let wrap input = $"\"{input}\""
-                writer.WriteStartObject()
-                match value with
-                | ModuleDeclaration moduleDecl ->
-                    nameof ModuleDeclaration |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, moduleDecl, typeof<ModuleDecl>, options)
-                | ActionDeclaration actionDecl ->
-                    nameof ActionDeclaration |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, actionDecl, typeof<ActionDecl>, options)
-                | MemberDeclaration memberDecl ->
-                    nameof MemberDeclaration |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, memberDecl, typeof<MemberDecl>, options)
-                | ClassDeclaration classDecl ->
-                    nameof ClassDeclaration |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, classDecl, typeof<ClassDecl>, options)
-                writer.WriteEndObject()
-    type NewArrayKindConverter() =
-        inherit Serialization.JsonConverter<NewArrayKind>()
-        override this.CanConvert typ = typ = typeof<NewArrayKind>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                let prefix postfix = $"{nameof NewArrayKind}.{postfix}"
-                let wrap input = $"\"{input}\""
-                writer.WriteStartObject()
-                match value with
-                | ArrayValues values ->
-                    nameof ArrayValues |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, values, typeof<Expr list>, options)
-                | ArrayAlloc size ->
-                    nameof ArrayAlloc |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, size, typeof<Expr>, options)
-                | ArrayFrom expr ->
-                    nameof ArrayFrom |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, expr, typeof<Expr>, options)
-                writer.WriteEndObject()
-    type GetKindConverter() =
-        inherit Serialization.JsonConverter<GetKind>()
-        override this.CanConvert typ = typ = typeof<GetKind>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                let prefix postfix = $"{nameof GetKind}.{postfix}"
-                let wrap input = $"\"{input}\""
-                match value with
-                | TupleIndex index ->
-                    writer.WriteStartObject()
-                    nameof TupleIndex |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, index, typeof<int>, options)
-                    writer.WriteEndObject()
-                | ExprGet expr ->
-                    writer.WriteStartObject()
-                    nameof ExprGet |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, expr, typeof<Expr>, options)
-                    writer.WriteEndObject()
-                | FieldGet info ->
-                    writer.WriteStartObject()
-                    nameof FieldGet |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, info, typeof<FieldInfo>, options)
-                    writer.WriteEndObject()
-                | UnionField info ->
-                    writer.WriteStartObject()
-                    nameof UnionField |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, info, typeof<UnionFieldInfo>, options)
-                    writer.WriteEndObject()
-                | UnionTag -> nameof UnionTag |> prefix |> wrap |> (fun v -> writer.WriteRawValue(v, true))
-                | ListHead -> nameof ListHead |> prefix |> wrap |> (fun v -> writer.WriteRawValue(v, true))
-                | ListTail -> nameof ListTail |> prefix |> wrap |> (fun v -> writer.WriteRawValue(v, true))
-                | OptionValue -> nameof OptionValue |> prefix |> wrap |> (fun v -> writer.WriteRawValue(v, true))
-    type SetKindConverter() =
-        inherit Serialization.JsonConverter<SetKind>()
-        override this.CanConvert typ = typ = typeof<SetKind>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                let prefix postfix = $"{nameof SetKind}.{postfix}"
-                let wrap input = $"\"{input}\""
-                match value with
-                | ExprSet expr ->
-                    writer.WriteStartObject()
-                    nameof ExprSet |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, expr, typeof<Expr>, options)
-                    writer.WriteEndObject()
-                | FieldSet fieldName ->
-                    writer.WriteStartObject()
-                    nameof FieldSet |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, fieldName, typeof<string>, options)
-                    writer.WriteEndObject()
-                | ValueSet -> nameof ValueSet |> prefix |> wrap |> (fun v -> writer.WriteRawValue(v, true))
-    type TestKindConverter() =
-        inherit Serialization.JsonConverter<TestKind>()
-        override this.CanConvert typ = typ = typeof<TestKind>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                let prefix postfix = $"{nameof TestKind}.{postfix}"
-                writer.WriteStartObject()
-                match value with
-                | TypeTest typ ->
-                    nameof TypeTest |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, typ, typeof<Fable.Type>, options)
-                | OptionTest isSome ->
-                    nameof OptionTest |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, isSome, typeof<bool>, options)
-                | ListTest isCons ->
-                    nameof ListTest |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, isCons, typeof<bool>, options)
-                | UnionCaseTest tag ->
-                    nameof UnionCaseTest |> prefix |> writer.WritePropertyName
-                    JsonSerializer.Serialize(writer, tag, typeof<int>, options)
-                writer.WriteEndObject()
-    type ExtendedSetConverter() =
-        inherit Serialization.JsonConverter<ExtendedSet>()
-        override this.CanConvert typ = typ = typeof<ExtendedSet>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                writer.WriteRawValue("\"TODO_EXTENDEDSET\"", true)
-    type UnresolvedExprConverter() =
-        inherit Serialization.JsonConverter<UnresolvedExpr>()
-        override this.CanConvert typ = typ = typeof<UnresolvedExpr>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                writer.WriteRawValue("\"TODO_UNRESOLVEDEXPR\"", true)
-    type OperationKindConverter() =
-        inherit Serialization.JsonConverter<OperationKind>()
-        override this.CanConvert typ = typ = typeof<OperationKind>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                writer.WriteRawValue("\"TODO_OPERATIONKIND\"", true)
-    type NumberKindConverter() =
-        inherit Serialization.JsonConverter<NumberKind>()
-        override this.CanConvert typ = typ = typeof<NumberKind>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                writer.WriteRawValue("\"TODO_NumberKindConverter\"", true)
-    type RegexFlagConverter() =
-        inherit Serialization.JsonConverter<RegexFlag>()
-        override this.CanConvert typ = typ = typeof<RegexFlag>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                writer.WriteRawValue("\"TODO_RegexFlagConverter\"", true)
-    type UnaryOperatorConverter() =
-        inherit Serialization.JsonConverter<UnaryOperator>()
-        override this.CanConvert typ = typ = typeof<UnaryOperator>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                writer.WriteRawValue("\"TODO_UnaryOperatorConverter\"", true)
-    type BinaryOperatorConverter() =
-        inherit Serialization.JsonConverter<BinaryOperator>()
-        override this.CanConvert typ = typ = typeof<BinaryOperator>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                writer.WriteRawValue("\"TODO_BINARYOPERATOR\"")
-    type LogicalOperatorConverter() =
-        inherit Serialization.JsonConverter<LogicalOperator>()
-        override this.CanConvert typ = typ = typeof<LogicalOperator>
-        override this.Read(_, _, _) = unbox null
-        override this.Write(writer, value, options) =
-            if canWrite writer then
-                writer.WriteRawValue("\"TODO_LOGICALOPERATOR\"")
+    let bind (tracer: Tracer<'T>) (input: 'M) : Tracer<'M> =
+        _create input tracer.Guid tracer.ConsoleColor
 
-    let options = JsonSerializerOptions(JsonSerializerDefaults.General)
-    options.Converters.Add(EntityPathConverter())
-    options.Converters.Add(MemberRefConverter())
-    options.Converters.Add(GeneratedMemberConverter())
-    options.Converters.Add(NumberInfoConverter())
-    options.Converters.Add(NumberValueConverter())
-    options.Converters.Add(ArrayKindConverter())
-    options.Converters.Add(ConstraintConverter())
-    options.Converters.Add(TypeConverter())
-    options.Converters.Add(ExprConverter())
-    options.Converters.Add(ValueKindConverter())
-    options.Converters.Add(TagSourceConverter())
-    options.Converters.Add(TagInfoConverter())
-    options.Converters.Add(ImportKindConverter())
-    options.Converters.Add(DeclarationConverter())
-    options.Converters.Add(NewArrayKindConverter())
-    options.Converters.Add(GetKindConverter())
-    options.Converters.Add(SetKindConverter())
-    options.Converters.Add(TestKindConverter())
-    options.Converters.Add(ExtendedSetConverter())
-    options.Converters.Add(UnresolvedExprConverter())
-    options.Converters.Add(OperationKindConverter())
-    options.Converters.Add(NumberKindConverter())
-    options.Converters.Add(RegexFlagConverter())
-    options.Converters.Add(UnaryOperatorConverter())
-    options.Converters.Add(BinaryOperatorConverter())
-    options.Converters.Add(LogicalOperatorConverter())
+    let map (func: 'T -> 'M) (tracer: Tracer<'T>) = func tracer.Value |> bind tracer
 
-    // UN-UTILISED ATM
-    /// ANSI Escape Sequences to colorize strings when directed to output.
-    [<AutoOpen>]
-    module private FColor =
-        type private FColor = string
-        /// When the output is not directed to console (ie directed to a file) then the escape sequence is not written
-        let private _fcolor value =
-            if Console.IsOutputRedirected then "" else value
 
-        /// Applies Color to value only. Returns color to normal after.
-        let colorize (color: FColor) (value: string) = $"{color}{value}{NORMAL}"
-        // Presets
-        let NORMAL: FColor = _fcolor "\x1b[39m" // Normal
-        let REVERSE: FColor = _fcolor "\x1b[7m" // Inverts Foreground and Background colors
-        let NOREVERSE: FColor = _fcolor "\x1b[27m" // Reverts Foreground and Background colors
-        // Colors
-        let RED: FColor = _fcolor "\x1b[91m"
-        let GREEN: FColor = _fcolor "\x1b[92m"
-        let YELLOW: FColor = _fcolor "\x1b[93m"
-        let BLUE: FColor = _fcolor "\x1b[94m"
-        let MAGENTA: FColor = _fcolor "\x1b[95m"
-        let CYAN: FColor = _fcolor "\x1b[96m"
-        let GREY: FColor = _fcolor "\x1b[97m"
-        // Formatting
-        let BOLD: FColor = _fcolor "\x1b[1m" // Intense
-        let NOBOLD: FColor = _fcolor "\x1b[22m" // Normal intensity
-        let UNDERLINE: FColor = _fcolor "\x1b[4m" // Underlined
-        let NOUNDERLINE: FColor = _fcolor "\x1b[24m" // Remove any underline
+module JsonConverters =
+    open FSharp.Reflection
 
-// Public API point for plugin printing AST to string
+    let private incl converter = Settings.addConverter converter
+
+    let (|IsUnion|_|) (input: 'T) =
+        let typ = typeof<'T> in
+        if FSharpType.IsUnion typ then
+            FSharpValue.GetUnionFields(input, typ) |> Some
+        else
+            None
+
+    [<AbstractClass>]
+    type BasicConverter<'T>() =
+        inherit Serialization.JsonConverter<'T>()
+        override this.CanConvert typ = typ = typeof<'T>
+        override this.Read(_, _, _) = unbox null
+
+    type UnionConverter<'T>() =
+        inherit BasicConverter<'T>()
+        let typ = typeof<'T>
+        override this.Write(writer, value, options) =
+            match value with
+            // In the case where the value is a union, we perform reflection on the union
+            | IsUnion(unionValue, unionFields) ->
+                let unionName = $"{typ.Name}.{unionValue.Name}"
+                let fieldInfoArray = unionValue.GetFields()
+                let (|NoFields|SingleField|MultipleFields|) (input: Reflection.PropertyInfo array) =
+                    match input with
+                    | [||] -> NoFields
+                    | [| field |] -> SingleField field
+                    | fields -> MultipleFields(fields |> Array.toList)
+                match fieldInfoArray with
+                | NoFields -> writer.WriteRawValue(sprintf "\"%s\"" unionName, true)
+                // Union name is value
+                | SingleField field ->
+                    writer.WriteStartObject()
+                    writer.WritePropertyName unionName
+                    JsonSerializer.Serialize(writer, unionFields[0], field.PropertyType, options)
+                    writer.WriteEndObject()
+                // pass field directly to serializer
+                | MultipleFields fields ->
+                    // Embed the union name at the beginning of the object, and then follow up with the fields
+                    writer.WriteStartObject()
+                    writer.WriteString(unionName, "_")
+                    // now we go through the fields and write the name of the field and then its value serialized
+                    for (info, field) in List.zip fields (unionFields |> Array.toList) do
+                        writer.WritePropertyName info.Name
+                        JsonSerializer.Serialize(writer, field, info.PropertyType, options)
+                    writer.WriteEndObject()
+            // Every other type can be serialized natively, so we will pass them to the serializer to manage
+            | _ -> JsonSerializer.Serialize(writer, value, typ, options)
+
+    let register<'T> = UnionConverter<'T>() |> incl
+    register<EntityPath>
+    register<MemberRef>
+    register<GeneratedMember>
+    register<NumberInfo>
+    register<NumberValue>
+    register<ArrayKind>
+    register<Constraint>
+    register<Fable.Type>
+    register<Fable.Expr>
+    register<ValueKind>
+    register<ImportKind>
+    register<Declaration>
+    register<NewArrayKind>
+    register<GetKind>
+    register<SetKind>
+    register<TestKind>
+    register<ExtendedSet>
+    register<UnresolvedExpr>
+    register<OperationKind>
+    register<NumberKind>
+    register<RegexFlag>
+    register<UnaryOperator>
+    register<BinaryOperator>
+    register<LogicalOperator>
+    register<TagInfo>
+    register<TagSource>
 type PrettyPrinter =
-    static member print(value: 'T) : string =
-        JsonSerializer.Serialize(value, PrettyPrint.options)
+    static member print(input: 'T) : string =
+        JsonSerializer.Serialize(input, Settings.converterOptions())

--- a/src/Oxpecker.Solid.FablePlugin/Types.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Types.fs
@@ -42,7 +42,10 @@ module Types =
                 verbose <- true
                 if
                     helper.Options.Define |> List.exists((=) "OXPECKER_SOLID_MINIMAL")
-                    && not (helper.Options.Define |> List.exists(fun s -> s.StartsWith("OXPECKER_SOLID_DEBUG") || s = "OXPECKER_SOLID_TRACE"))
+                    && not(
+                        helper.Options.Define
+                        |> List.exists(fun s -> s.StartsWith("OXPECKER_SOLID_DEBUG") || s = "OXPECKER_SOLID_TRACE")
+                    )
                 then
                     jsonify <- false
                 elif helper.Options.Define |> List.exists((=) "OXPECKER_SOLID_TRACE") then
@@ -56,8 +59,8 @@ module Types =
                         |> String.Concat
                         |> int
                         |> fun i -> depth <- i
-                if jsonify && helper.Options.Define |> List.exists((=) "OXPECKER_SOLID_MINIMAL")
-                then slim <- true
+                if jsonify && helper.Options.Define |> List.exists((=) "OXPECKER_SOLID_MINIMAL") then
+                    slim <- true
         static member Verbose() = verbose
         static member Verbose value = verbose <- value
         static member Slim() = slim

--- a/src/Oxpecker.Solid.FablePlugin/Types.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Types.fs
@@ -4,6 +4,7 @@ open System
 open Fable.AST
 open Fable.AST.Fable
 
+
 module Types =
     type Tracer<'T> = {
         Value: 'T
@@ -30,3 +31,30 @@ module Types =
         | WithChildren of tagName: TagSource * propsAndChildren: CallInfo * range: SourceLocation option
         | NoChildren of tagName: TagSource * props: Expr list * range: SourceLocation option
         | Combined of tagName: TagSource * props: Expr list * propsAndChildren: CallInfo * range: SourceLocation option
+
+    type PluginConfiguration() =
+        static let mutable verbose = false
+        static let mutable depth = 4
+        static let mutable jsonify = true
+        static member configure(helper: Fable.PluginHelper) =
+            if helper.Options.Define |> List.exists(fun s -> s.StartsWith "OXPECKER_SOLID_") then
+                verbose <- true
+            if helper.Options.Define |> List.exists((=) "OXPECKER_SOLID_MINIMAL") then
+                jsonify <- false
+            elif helper.Options.Define |> List.exists((=) "OXPECKER_SOLID_TRACE") then
+                depth <- 0
+            else
+                for definition in
+                    helper.Options.Define
+                    |> List.filter(fun s -> s.StartsWith "OXPECKER_SOLID_DEBUG_") do
+                    definition.ToCharArray()
+                    |> Array.filter Char.IsDigit
+                    |> string
+                    |> int
+                    |> fun i -> depth <- i
+        static member Verbose() = verbose
+        static member Verbose value = verbose <- value
+        static member Depth() = depth
+        static member Depth value = depth <- value
+        static member Jsonify() = jsonify
+        static member Jsonify value = jsonify <- value

--- a/src/Oxpecker.Solid.FablePlugin/Types.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Types.fs
@@ -1,70 +1,25 @@
 ﻿namespace Oxpecker.Solid.FablePlugin
 
-open System
 open Fable.AST
 open Fable.AST.Fable
 
+/// <summary>
+/// AST Representation for a JSX Attribute/property. Tuple of name and value
+/// </summary>
+type PropInfo = string * Expr
+/// <summary>
+/// List of AST property name value pairs
+/// </summary>
+type Props = PropInfo list
 
-module Types =
-    type Tracer<'T> = {
-        Value: 'T
-        Guid: Guid
-        ConsoleColor: ConsoleColor
-    }
-    /// <summary>
-    /// AST Representation for a JSX Attribute/property. Tuple of name and value
-    /// </summary>
-    type PropInfo = string * Expr
-    /// <summary>
-    /// List of AST property name value pairs
-    /// </summary>
-    type Props = PropInfo list
-
-    type TagSource =
-        | AutoImport of tagName: string
-        | LibraryImport of imp: Expr
-    /// <summary>
-    /// DU which distinguishes between a user call instantiating the tag with children, without children (props only),
-    /// or with both children AND properties.
-    /// </summary>
-    type TagInfo =
-        | WithChildren of tagName: TagSource * propsAndChildren: CallInfo * range: SourceLocation option
-        | NoChildren of tagName: TagSource * props: Expr list * range: SourceLocation option
-        | Combined of tagName: TagSource * props: Expr list * propsAndChildren: CallInfo * range: SourceLocation option
-
-    type PluginConfiguration() =
-        static let mutable verbose = false
-        static let mutable depth = 4
-        static let mutable jsonify = true
-        static let mutable slim = false
-        static member configure(helper: Fable.PluginHelper) =
-            if helper.Options.Define |> List.exists(fun s -> s.StartsWith "OXPECKER_SOLID_") then
-                verbose <- true
-                if
-                    helper.Options.Define |> List.exists((=) "OXPECKER_SOLID_MINIMAL")
-                    && not(
-                        helper.Options.Define
-                        |> List.exists(fun s -> s.StartsWith("OXPECKER_SOLID_DEBUG") || s = "OXPECKER_SOLID_TRACE")
-                    )
-                then
-                    jsonify <- false
-                elif helper.Options.Define |> List.exists((=) "OXPECKER_SOLID_TRACE") then
-                    depth <- 0
-                else
-                    for definition in
-                        helper.Options.Define
-                        |> List.filter(fun s -> s.StartsWith "OXPECKER_SOLID_DEBUG_") do
-                        definition.ToCharArray()
-                        |> Array.filter Char.IsDigit
-                        |> String.Concat
-                        |> int
-                        |> fun i -> depth <- i
-                if jsonify && helper.Options.Define |> List.exists((=) "OXPECKER_SOLID_MINIMAL") then
-                    slim <- true
-        static member Verbose() = verbose
-        static member Verbose value = verbose <- value
-        static member Slim() = slim
-        static member Depth() = depth
-        static member Depth value = depth <- value
-        static member Jsonify() = jsonify
-        static member Jsonify value = jsonify <- value
+type TagSource =
+    | AutoImport of tagName: string
+    | LibraryImport of imp: Expr
+/// <summary>
+/// DU which distinguishes between a user call instantiating the tag with children, without children (props only),
+/// or with both children AND properties.
+/// </summary>
+type TagInfo =
+    | WithChildren of tagName: TagSource * propsAndChildren: CallInfo * range: SourceLocation option
+    | NoChildren of tagName: TagSource * props: Expr list * range: SourceLocation option
+    | Combined of tagName: TagSource * props: Expr list * propsAndChildren: CallInfo * range: SourceLocation option

--- a/src/Oxpecker.Solid.FablePlugin/Types.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Types.fs
@@ -1,0 +1,32 @@
+﻿namespace Oxpecker.Solid.FablePlugin
+
+open System
+open Fable.AST
+open Fable.AST.Fable
+
+module Types =
+    type Tracer<'T> = {
+        Value: 'T
+        Guid: Guid
+        ConsoleColor: ConsoleColor
+    }
+    /// <summary>
+    /// AST Representation for a JSX Attribute/property. Tuple of name and value
+    /// </summary>
+    type PropInfo = string * Expr
+    /// <summary>
+    /// List of AST property name value pairs
+    /// </summary>
+    type Props = PropInfo list
+
+    type TagSource =
+        | AutoImport of tagName: string
+        | LibraryImport of imp: Expr
+    /// <summary>
+    /// DU which distinguishes between a user call instantiating the tag with children, without children (props only),
+    /// or with both children AND properties.
+    /// </summary>
+    type TagInfo =
+        | WithChildren of tagName: TagSource * propsAndChildren: CallInfo * range: SourceLocation option
+        | NoChildren of tagName: TagSource * props: Expr list * range: SourceLocation option
+        | Combined of tagName: TagSource * props: Expr list * propsAndChildren: CallInfo * range: SourceLocation option

--- a/src/Oxpecker.Solid.FablePlugin/Types.fs
+++ b/src/Oxpecker.Solid.FablePlugin/Types.fs
@@ -36,24 +36,31 @@ module Types =
         static let mutable verbose = false
         static let mutable depth = 4
         static let mutable jsonify = true
+        static let mutable slim = false
         static member configure(helper: Fable.PluginHelper) =
             if helper.Options.Define |> List.exists(fun s -> s.StartsWith "OXPECKER_SOLID_") then
                 verbose <- true
-            if helper.Options.Define |> List.exists((=) "OXPECKER_SOLID_MINIMAL") then
-                jsonify <- false
-            elif helper.Options.Define |> List.exists((=) "OXPECKER_SOLID_TRACE") then
-                depth <- 0
-            else
-                for definition in
-                    helper.Options.Define
-                    |> List.filter(fun s -> s.StartsWith "OXPECKER_SOLID_DEBUG_") do
-                    definition.ToCharArray()
-                    |> Array.filter Char.IsDigit
-                    |> string
-                    |> int
-                    |> fun i -> depth <- i
+                if
+                    helper.Options.Define |> List.exists((=) "OXPECKER_SOLID_MINIMAL")
+                    && not (helper.Options.Define |> List.exists(fun s -> s.StartsWith("OXPECKER_SOLID_DEBUG") || s = "OXPECKER_SOLID_TRACE"))
+                then
+                    jsonify <- false
+                elif helper.Options.Define |> List.exists((=) "OXPECKER_SOLID_TRACE") then
+                    depth <- 0
+                else
+                    for definition in
+                        helper.Options.Define
+                        |> List.filter(fun s -> s.StartsWith "OXPECKER_SOLID_DEBUG_") do
+                        definition.ToCharArray()
+                        |> Array.filter Char.IsDigit
+                        |> String.Concat
+                        |> int
+                        |> fun i -> depth <- i
+                if jsonify && helper.Options.Define |> List.exists((=) "OXPECKER_SOLID_MINIMAL")
+                then slim <- true
         static member Verbose() = verbose
         static member Verbose value = verbose <- value
+        static member Slim() = slim
         static member Depth() = depth
         static member Depth value = depth <- value
         static member Jsonify() = jsonify

--- a/tests/Oxpecker.Solid.Tests/Oxpecker.Solid.Tests.fsproj
+++ b/tests/Oxpecker.Solid.Tests/Oxpecker.Solid.Tests.fsproj
@@ -81,6 +81,9 @@
         <None Include="SolidCases\LibraryImports\LibraryImports.fsproj" />
         <None Include="SolidCases\LibraryImports\LibraryImports.FABLE5" />
         <None Include="SolidCases\LibraryImports\LibraryImports.expected" />
+        <Compile Include="SolidCases\LibraryImportsChildren\LibraryImportsChildren.fs" />
+        <None Include="SolidCases\LibraryImportsChildren\LibraryImportsChildren.fsproj" />
+        <None Include="SolidCases\LibraryImportsChildren\LibraryImportsChildren.expected" />
         <Compile Include="Common.fs" />
         <Compile Include="GeneralTests.fs" />
         <Compile Include="SolidTests.fs" />

--- a/tests/Oxpecker.Solid.Tests/Oxpecker.Solid.Tests.fsproj
+++ b/tests/Oxpecker.Solid.Tests/Oxpecker.Solid.Tests.fsproj
@@ -76,6 +76,11 @@
         <Compile Include="SolidCases\Router\App2.fs" />
         <Compile Include="SolidCases\Router\Router.fs" />
         <Content Include="SolidCases\Router\Router.fsproj" />
+        <Compile Include="SolidCases\LibraryImports\Types.fs" />
+        <Compile Include="SolidCases\LibraryImports\LibraryImports.fs" />
+        <None Include="SolidCases\LibraryImports\LibraryImports.fsproj" />
+        <None Include="SolidCases\LibraryImports\LibraryImports.FABLE5" />
+        <None Include="SolidCases\LibraryImports\LibraryImports.expected" />
         <Compile Include="Common.fs" />
         <Compile Include="GeneralTests.fs" />
         <Compile Include="SolidTests.fs" />

--- a/tests/Oxpecker.Solid.Tests/Oxpecker.Solid.Tests.fsproj
+++ b/tests/Oxpecker.Solid.Tests/Oxpecker.Solid.Tests.fsproj
@@ -79,7 +79,6 @@
         <Compile Include="SolidCases\LibraryImports\Types.fs" />
         <Compile Include="SolidCases\LibraryImports\LibraryImports.fs" />
         <None Include="SolidCases\LibraryImports\LibraryImports.fsproj" />
-        <None Include="SolidCases\LibraryImports\LibraryImports.FABLE5" />
         <None Include="SolidCases\LibraryImports\LibraryImports.expected" />
         <Compile Include="SolidCases\LibraryImportsChildren\LibraryImportsChildren.fs" />
         <None Include="SolidCases\LibraryImportsChildren\LibraryImportsChildren.fsproj" />

--- a/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImports/LibraryImports.FABLE5
+++ b/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImports/LibraryImports.FABLE5
@@ -1,0 +1,7 @@
+﻿import { Faketag } from "fakemodule";
+
+export function Button() {
+    return <Faketag class="TEST"
+        key="value" />;
+}
+

--- a/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImports/LibraryImports.FABLE5
+++ b/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImports/LibraryImports.FABLE5
@@ -1,7 +1,0 @@
-﻿import { Faketag } from "fakemodule";
-
-export function Button() {
-    return <Faketag class="TEST"
-        key="value" />;
-}
-

--- a/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImports/LibraryImports.expected
+++ b/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImports/LibraryImports.expected
@@ -1,7 +1,12 @@
 ﻿import { Faketag } from "fakemodule";
 
 export function Button() {
-    return <Faketag class="TEST"
-        key="value"></Faketag>;
+    return <div>
+        <Faketag class="TEST"
+            key="value"></Faketag>
+        <Faketag key="value"></Faketag>
+        <Faketag key="value"
+            some="other"></Faketag>
+    </div>;
 }
 

--- a/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImports/LibraryImports.expected
+++ b/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImports/LibraryImports.expected
@@ -1,0 +1,7 @@
+﻿import { Faketag } from "fakemodule";
+
+export function Button() {
+    return <Faketag class="TEST"
+        key="value"></Faketag>;
+}
+

--- a/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImports/LibraryImports.fs
+++ b/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImports/LibraryImports.fs
@@ -1,0 +1,9 @@
+﻿module Oxpecker.Solid.Tests.Cases.LibraryImports
+
+open Oxpecker.Solid
+open Oxpecker.Solid.Tests.Cases.Types
+
+
+[<SolidComponent>]
+let Button () =
+    ImportedTag(class'="TEST").attr("key","value")

--- a/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImports/LibraryImports.fs
+++ b/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImports/LibraryImports.fs
@@ -6,4 +6,8 @@ open Oxpecker.Solid.Tests.Cases.Types
 
 [<SolidComponent>]
 let Button () =
-    ImportedTag(class'="TEST").attr("key","value")
+    div() {
+        ImportedTag(class'="TEST").attr("key","value")
+        ImportedTag().attr("key","value")
+        ImportedTag().attr("key","value").attr("some","other")
+    }

--- a/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImports/LibraryImports.fsproj
+++ b/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImports/LibraryImports.fsproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Types.fs" />
+    <Compile Include="LibraryImports.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Oxpecker.Solid\Oxpecker.Solid.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImports/Types.fs
+++ b/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImports/Types.fs
@@ -1,0 +1,8 @@
+﻿module Oxpecker.Solid.Tests.Cases.Types
+
+open Oxpecker.Solid
+open Fable.Core
+
+[<Import("Faketag","fakemodule")>]
+type ImportedTag() =
+    inherit RegularNode()

--- a/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImportsChildren/LibraryImportsChildren.expected
+++ b/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImportsChildren/LibraryImportsChildren.expected
@@ -1,0 +1,9 @@
+﻿import { Faketag } from "fakemodule";
+
+export function Button() {
+    return <Faketag class="TEST"
+        key="value">
+        Child
+    </Faketag>;
+}
+

--- a/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImportsChildren/LibraryImportsChildren.fs
+++ b/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImportsChildren/LibraryImportsChildren.fs
@@ -1,0 +1,9 @@
+﻿module Oxpecker.Solid.Tests.Cases.LibraryImportsChildren
+
+open Oxpecker.Solid
+open Oxpecker.Solid.Tests.Cases.Types
+
+
+[<SolidComponent>]
+let Button () =
+    ImportedTag(class'="TEST").attr("key","value") { "Child" }

--- a/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImportsChildren/LibraryImportsChildren.fsproj
+++ b/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImportsChildren/LibraryImportsChildren.fsproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Types.fs" />
+    <Compile Include="../LibraryImports/Types.fs" />
     <Compile Include="LibraryImportsChildren.fs" />
   </ItemGroup>
 

--- a/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImportsChildren/LibraryImportsChildren.fsproj
+++ b/tests/Oxpecker.Solid.Tests/SolidCases/LibraryImportsChildren/LibraryImportsChildren.fsproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Types.fs" />
+    <Compile Include="LibraryImportsChildren.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Oxpecker.Solid\Oxpecker.Solid.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Oxpecker.Solid.Tests/SolidTests.fs
+++ b/tests/Oxpecker.Solid.Tests/SolidTests.fs
@@ -38,3 +38,7 @@ let ``Router`` () =
 [<Fact>]
 let ``LibraryImports`` () =
     runSolidCase "LibraryImports"
+
+[<Fact>]
+let ``LibraryImportsChildren`` () =
+    runSolidCase "LibraryImportsChildren"

--- a/tests/Oxpecker.Solid.Tests/SolidTests.fs
+++ b/tests/Oxpecker.Solid.Tests/SolidTests.fs
@@ -34,3 +34,7 @@ let ``Refs`` () =
 [<Fact>]
 let ``Router`` () =
     runSolidCase "Router"
+
+[<Fact>]
+let ``LibraryImports`` () =
+    runSolidCase "LibraryImports"


### PR DESCRIPTION
> Reattempt at #53 which was abandoned because it potentially had altered behaviour from the beginning. This uses continuous testing with the present suite of tests rather than relying on errors coming up when trying to fix #52 #54 

Tracer is type agnostic so we can pass it around everywhere.

```fs
type Tracer<'T> =
    {
        Value : 'T
        Guid : Guid
        ConsoleColor : ConsoleColor
    }
```

![image](https://github.com/user-attachments/assets/9a5e1e9a-0074-47e1-9165-2a3317c95c14)

![image](https://github.com/user-attachments/assets/d5bb5ef8-1b5c-4ad5-b028-456740a4c533)

# STAGE

- [x] Tracer Implementation
- [x] Fix #54 
- [ ] Fix #52 

## What does this Pull change

* Refactored the Fable Plugin to collate similar patterns into modules for easier identification
* Introduced a Tracer for debugging transformations
* Fixes targeting library imports being missed when combined with element extension

## New Functionality

The tracer allows you to pass compiler directives to fable to induce the debugging behaviour.

* `--define OXPECKER_SOLID_MINIMAL` - this will emit the order of operations to std out
* `--define OXPECKER_SOLID_DEBUG` - this will emit the order of operations and JSON for marked expressions in the plugin to a max depth of 4
* `--define OXPECKER_SOLID_DEBUG_[n]` - where `[n]` is any integer. This will emit the order of operations and JSON for marked expressions up to a max depth of `[n]`
* `--define OXPECKER_SOLID_TRACE` - Emits the order of operations and JSON without limit. This is best combined with the following directive:
* `--define OXPECKER_SOLID_FILE` - This pipes the order of operations and JSON (or whatever the current configured behaviour is) to a timestamped txt file in the CWD. It will not print JSON to stdout, but it WILL still print the order of operations. This is because the order of operations have source code links that are useful for navigating the plugin while you're debugging.

While adding code or new branches of logic in pattern matching, you can emit information to provide context to the flow of operations. This is done with `Tracer.ping()` with optional messages `Tracer.ping("SingleField branch")`.

You create a Tracer object (which is differentiated by the fact that it is associated with a GUID, which is useful if you want distinguish different 'collections' of operations or expressions in groups) by passing a value to `Tracer.create`.

A tracer is a simple record:

```fs
type Tracer<'T> = { Value = 'T; Guid = Guid; ConsoleColor = ConsoleColor }
```

You can emit the JSON and position of the tracer by pinging it, or tracing it

```fs
tracer.ping() // unit output
tracer.ping("extra context") // with optional message
tracer.trace() |> ignore // outputs itself
tracer.trace("extra context") // with optional message
```

If you want to bind a new value to the tracer (and keep the GUID), use `Tracer.bind`. Similarly, there is a `Tracer.map` function for applying functions to the internal value.

```fs
newExpr |> Tracer.bind tracer
```

The JsonConverters are automatically generated for Unions in a manner that I feel is the most helpful.
Any new unions added just have to be registered in the `PrettyPrint.fs` file in the JsonConverters module:

```fs
register<Fable.Expr>
register<SomeNewUnionType>
```

The rest is taken care of.