### PR TITLE
Oxpecker.Solid - Add Secondary Primitives

### DIFF
--- a/src/Oxpecker.Solid/SolidBindings.fs
+++ b/src/Oxpecker.Solid/SolidBindings.fs
@@ -617,13 +617,6 @@ module Bindings =
         static member inline Find(this: SolidStorePath<'T, 'Value array>, predicate: 'Value -> bool) =
             SolidStorePath<'T, 'Value>(this.Setter, Array.append this.Path [| predicate |])
 
-[<Global; AllowNullLiteral>]
-type CreateDeferredOptions
-    [<ParamObject; Emit("$0")>]
-    (?timeoutMs: int, ?equals: U2<bool, obj * obj -> bool>, ?name: string) =
-    member val timeoutMs = timeoutMs with get, set
-    member val equals = equals with get, set
-    member val name = name with get, set
 
 [<AutoOpen>]
 [<Erase>]
@@ -635,8 +628,11 @@ type Bindings =
     [<ImportMember("solid-js/web")>]
     static member renderToString(fn: unit -> #HtmlElement) : string = jsNative
 
-    [<ImportMember("solid-js")>]
-    static member createSignal(value: 'T) : Signal<'T> = jsNative
+    [<ImportMember("solid-js"); ParamObject(1)>]
+    static member createSignal
+        (value: 'T, ?equals: ('T -> 'T -> bool), ?name: string, ?``internal``: bool)
+        : Signal<'T> =
+        jsNative
 
     [<ImportMember("solid-js")>]
     static member createMemo(value: unit -> 'T) : (unit -> 'T) = jsNative
@@ -727,8 +723,11 @@ type Bindings =
     /// Creates a readonly that only notifies downstream changes when the browser is idle. <c>timeoutMs</c> is the
     /// maximum time to wait before forcing the update.
     /// </summary>
-    [<ImportMember("solid-js")>]
-    static member createDeferred<'T>(source: unit -> 'T, ?options: CreateDeferredOptions) : unit -> 'T = jsNative
+    [<ImportMember("solid-js"); ParamObject(1)>]
+    static member createDeferred<'T>
+        (source: unit -> 'T, ?timeoutMs: int, ?equals: 'T -> 'T -> bool, ?name: string)
+        : unit -> 'T =
+        jsNative
     /// <summary>
     /// Sometimes it is useful to separate tracking from re-execution. This primitive registers a side-effect
     /// that is run the first time the expression wrapped by the returned tracking is notified of a change.
@@ -759,4 +758,4 @@ type Bindings =
     /// <param name="source">The source signal to get the value from and compare with keys.</param>
     /// <param name="fn">A function to compare the key and the value, returning whether they should be treated as equal. Default: <c>=</c></param>
     [<ImportMember("solid-js")>]
-    static member createSelector<'T, 'U>(source: unit -> 'T, ?fn: ('U * 'T) -> bool) : 'U -> bool = jsNative
+    static member createSelector<'T, 'U>(source: unit -> 'T, ?fn: 'U -> 'T -> bool) : 'U -> bool = jsNative

--- a/src/Oxpecker.Solid/SolidBindings.fs
+++ b/src/Oxpecker.Solid/SolidBindings.fs
@@ -618,14 +618,12 @@ module Bindings =
             SolidStorePath<'T, 'Value>(this.Setter, Array.append this.Path [| predicate |])
 
 [<Global; AllowNullLiteral>]
-type CreateDeferredOptions [<ParamObject; Emit("$0")>] (
-        ?timeoutMs: int,
-        ?equals: U2<bool, obj * obj -> bool>,
-        ?name: string
-    )  =
-    member val timeoutMs = timeoutMs with get,set
-    member val equals = equals with get,set
-    member val name = name with get,set
+type CreateDeferredOptions
+    [<ParamObject; Emit("$0")>]
+    (?timeoutMs: int, ?equals: U2<bool, obj * obj -> bool>, ?name: string) =
+    member val timeoutMs = timeoutMs with get, set
+    member val equals = equals with get, set
+    member val name = name with get, set
 
 [<AutoOpen>]
 [<Erase>]
@@ -724,19 +722,19 @@ type Bindings =
     /// <param name="fn">The function to run in a tracking scope.</param>
     /// <param name="value">The initial value to pass to the function.</param>
     [<ImportMember("solid-js")>]
-    static member createComputed<'T>(fn: 'T -> 'T, ?value: 'T): unit = jsNative
+    static member createComputed<'T>(fn: 'T -> 'T, ?value: 'T) : unit = jsNative
     /// <summary>
     /// Creates a readonly that only notifies downstream changes when the browser is idle. <c>timeoutMs</c> is the
     /// maximum time to wait before forcing the update.
     /// </summary>
     [<ImportMember("solid-js")>]
-    static member createDeferred<'T>(source: unit -> 'T, ?options: CreateDeferredOptions): unit -> 'T = jsNative
+    static member createDeferred<'T>(source: unit -> 'T, ?options: CreateDeferredOptions) : unit -> 'T = jsNative
     /// <summary>
     /// Sometimes it is useful to separate tracking from re-execution. This primitive registers a side-effect
     /// that is run the first time the expression wrapped by the returned tracking is notified of a change.
     /// </summary>
     [<ImportMember("solid-js")>]
-    static member createReaction(onInvalidate: unit -> unit): (unit -> unit) -> unit = jsNative
+    static member createReaction(onInvalidate: unit -> unit) : (unit -> unit) -> unit = jsNative
     /// <summary>
     /// A render effect is a computation similar to a regular effect, but differs in when Solid schedules
     /// the first execution of the effect function. While createEffect waits for the current rendering
@@ -747,7 +745,7 @@ type Bindings =
     /// the rendering phase of itself, including setting of <b>refs</b>
     /// </summary>
     [<ImportMember("solid-js")>]
-    static member createRenderEffect<'T>(fn: 'T -> 'T, ?value: 'T): unit = jsNative
+    static member createRenderEffect<'T>(fn: 'T -> 'T, ?value: 'T) : unit = jsNative
     /// <summary>
     /// Creates a parameterised derived boolean signal <c>selector(key)</c> that indicates whether <c>key</c>
     /// is equal to the current value of the <c>source</c> signal. These signals are optimised to notify
@@ -761,4 +759,4 @@ type Bindings =
     /// <param name="source">The source signal to get the value from and compare with keys.</param>
     /// <param name="fn">A function to compare the key and the value, returning whether they should be treated as equal. Default: <c>=</c></param>
     [<ImportMember("solid-js")>]
-    static member createSelector<'T, 'U>(source: unit -> 'T, ?fn: ('U * 'T) -> bool): 'U -> bool = jsNative
+    static member createSelector<'T, 'U>(source: unit -> 'T, ?fn: ('U * 'T) -> bool) : 'U -> bool = jsNative

--- a/src/Oxpecker.Solid/SolidBindings.fs
+++ b/src/Oxpecker.Solid/SolidBindings.fs
@@ -633,6 +633,8 @@ type Bindings =
         (value: 'T, ?equals: ('T -> 'T -> bool), ?name: string, ?``internal``: bool)
         : Signal<'T> =
         jsNative
+    [<ImportMember("solid-js")>]
+    static member createSignal(value: 'T) : Signal<'T> = jsNative
 
     [<ImportMember("solid-js")>]
     static member createMemo(value: unit -> 'T) : (unit -> 'T) = jsNative
@@ -728,6 +730,12 @@ type Bindings =
         (source: unit -> 'T, ?timeoutMs: int, ?equals: 'T -> 'T -> bool, ?name: string)
         : unit -> 'T =
         jsNative
+    /// <summary>
+    /// Creates a readonly that only notifies downstream changes when the browser is idle. <c>timeoutMs</c> is the
+    /// maximum time to wait before forcing the update.
+    /// </summary>
+    [<ImportMember("solid-js")>]
+    static member createDeferred<'T>(source: unit -> 'T) : unit -> 'T = jsNative
     /// <summary>
     /// Sometimes it is useful to separate tracking from re-execution. This primitive registers a side-effect
     /// that is run the first time the expression wrapped by the returned tracking is notified of a change.


### PR DESCRIPTION
Adds the secondary primitives as [per solid-js reference](https://docs.solidjs.com/reference/secondary-primitives/create-computed).

