### PR TITLE
Proposal: add cls attribute alias to class' for HtmlTag

### DIFF
--- a/src/Oxpecker.ViewEngine/Tags.fs
+++ b/src/Oxpecker.ViewEngine/Tags.fs
@@ -45,6 +45,9 @@ module Tags =
             with set (value: string | null) = this.attr("id", value) |> ignore
         member this.class'
             with set (value: string | null) = this.attr("class", value) |> ignore
+        /// Alias for class' attribute
+        member this.cls
+            with set (value: string | null) = this.attr("class", value) |> ignore
         [<LanguageInjection(InjectedLanguage.CSS, Prefix = ".x{", Suffix = ";}")>]
         member this.style
             with set (value: string | null) = this.attr("style", value) |> ignore


### PR DESCRIPTION
Hi,

because class' is used often (especially with tailwind) i feel like it would be nice to add a cls attribute that also sets class. This is already common in the scala ecosystem and i really enjoyed not having to do weird escaping all the time.
Now on the other hand i don't think its required for type' or base' as they are way less frequently used  but it might be good to consider it.

I am planning on using Oxpecker.ViewEngine for my own frontend/fullstack-ish framework built from the ground up in f# (kinda like sutil but less gimmicky and with ssr) and personally this is a vital part  for me to enjoy using it. (though if you do not want this upstreamed no problem i can just make an extension or maintain a custom fork)

Side note you have done an amazing job on Oxpecker keep doing amazing things. 