### PR TITLE
[Solid] Allow jsx elements from JSX.jsx as children of elements

### DIFF
--- a/src/Oxpecker.Solid/Builder.fs
+++ b/src/Oxpecker.Solid/Builder.fs
@@ -48,6 +48,9 @@ module Builder =
         [<Erase>]
         member inline _.Yield(text: int) : HtmlContainerFun = fun cont -> ignore text
 
+        [<Erase>]
+        member inline _.Yield(element: JSX.Element) : HtmlContainerFun = fun cont -> ignore element
+
     [<Erase>]
     type HtmlContainerExtensions =
         [<Extension; Erase>]


### PR DESCRIPTION
Simple tweak that allows builders to inherently accept JSX.Element type that is outputted by Fable.Core.JS.JSX.jsx