### PR TITLE
CSRF protection implementation in Oxpecker

### DIFF
--- a/examples/Empty/Program.fs
+++ b/examples/Empty/Program.fs
@@ -11,6 +11,9 @@ let main args =
     let builder = WebApplication.CreateBuilder(args)
     builder.Services.AddRouting().AddOxpecker() |> ignore
     let app = builder.Build()
-    app.UseRouting().UseOxpecker(endpoints) |> ignore
+    app.UseRouting()
+        .Use(DefaultHandlers.errorHandler)
+        .UseOxpecker(endpoints)
+        .Run(DefaultHandlers.notFoundHandler)
     app.Run()
     0 // Exit code

--- a/examples/WeatherApp/templates/weather.fs
+++ b/examples/WeatherApp/templates/weather.fs
@@ -1,30 +1,40 @@
 module WeatherApp.templates.weather
 
 open Microsoft.AspNetCore.Http
+open Oxpecker
 open Oxpecker.ViewEngine
 open Oxpecker.Htmx
 open WeatherApp.Models
 
-let data (forecasts: WeatherForecast[]) =
-    table(class'="table") {
-        thead() {
-            tr() {
-                th() { "Date" }
-                th() { "Temp. (C)" }
-                th() { "Temp. (F)" }
-                th() { "Summary" }
+let data (ctx: HttpContext) (forecasts: WeatherForecast[]) =
+    div(id="weatherData") {
+        table(class'="table") {
+            thead() {
+                tr() {
+                    th() { "Date" }
+                    th() { "Temp. (C)" }
+                    th() { "Temp. (F)" }
+                    th() { "Summary" }
+                }
+            }
+            tbody() {
+                for forecast in forecasts do
+                    tr() {
+                        td() { forecast.Date.ToShortDateString() }
+                        td() { string forecast.TemperatureC }
+                        td() { string forecast.TemperatureF }
+                        td() { forecast.Summary }
+                    }
             }
         }
-        tbody() {
-            for forecast in forecasts do
-                tr() {
-                    td() { forecast.Date.ToShortDateString() }
-                    td() { string forecast.TemperatureC }
-                    td() { string forecast.TemperatureF }
-                    td() { forecast.Summary }
-                }
+        form(action="/weatherData", hxTarget="#weatherData", hxSwap="outerHTML", hxPushUrl="false",
+             method="POST"){
+            ctx.GetAntiforgeryInput()
+            input(type'="hidden", name="test", value="test")
+            button(type'="submit") { "Refresh" }
         }
     }
+
 
 let html (ctx: HttpContext) =
     ctx.Items["Title"] <- "Weather"

--- a/src/Oxpecker/Handlers.fs
+++ b/src/Oxpecker/Handlers.fs
@@ -3,8 +3,10 @@ namespace Oxpecker
 
 open System.Collections.Generic
 open System.Threading.Tasks
+open Microsoft.AspNetCore.Antiforgery
 open Microsoft.AspNetCore.Http
 open Oxpecker.ViewEngine
+open Microsoft.Extensions.Logging
 
 [<AutoOpen>]
 module RequestHandlers =
@@ -190,3 +192,37 @@ module ResponseHandlers =
         fun (ctx: HttpContext) ->
             ctx.SetHttpHeader(key, value)
             Task.CompletedTask
+
+[<RequireQualifiedAccess>]
+module DefaultHandlers =
+    let errorHandler (ctx: HttpContext) (next: RequestDelegate) =
+        task {
+            try
+                return! next.Invoke(ctx)
+            with ex ->
+                let logger = ctx.GetLogger("Oxpecker.DefaultHandlers")
+                match ex with
+                | :? ModelBindException
+                | :? RouteParseException as ex ->
+                    logger.LogWarning(ex, "Invalid request {Method} {Path}", ctx.Request.Method, ctx.Request.Path)
+                    ctx.SetStatusCode StatusCodes.Status400BadRequest
+                | :? AntiforgeryValidationException as ex ->
+                    logger.LogWarning(
+                        ex,
+                        "CSRF token validation failed {Method} {Path}",
+                        ctx.Request.Method,
+                        ctx.Request.Path
+                    )
+                    ctx.SetStatusCode StatusCodes.Status403Forbidden
+                | ex ->
+                    logger.LogError(ex, "Unhandled exception {Method} {Path}", ctx.Request.Method, ctx.Request.Path)
+                    ctx.SetStatusCode StatusCodes.Status500InternalServerError
+                return! ctx.WriteText(ex.Message)
+        }
+        :> Task
+
+    let notFoundHandler (ctx: HttpContext) =
+        let logger = ctx.GetLogger("Oxpecker.DefaultHandlers")
+        logger.LogWarning("Page not found {Method} {Path}", ctx.Request.Method, ctx.Request.Path)
+        ctx.SetStatusCode 404
+        ctx.WriteText("Page not found")

--- a/src/Oxpecker/HttpContextExtensions.fs
+++ b/src/Oxpecker/HttpContextExtensions.fs
@@ -395,12 +395,10 @@ type HttpContextExtensions() =
         match feature with
         | null -> ()
         | f ->
-            match f.IsValid with
-            | true -> ()
-            | false ->
-                match f.Error with
-                | null -> ()
-                | err -> ExceptionDispatchInfo.Throw err
+            match f.IsValid, f.Error with
+            | true, _
+            | false, Null -> ()
+            | false, NonNull err -> ExceptionDispatchInfo.Throw err
         task {
             try
                 let! form = ctx.Request.ReadFormAsync()

--- a/src/Oxpecker/HttpContextExtensions.fs
+++ b/src/Oxpecker/HttpContextExtensions.fs
@@ -166,6 +166,7 @@ type HttpContextExtensions() =
     /// <summary>
     /// Gets an instance of <see cref="Microsoft.AspNetCore.Hosting.IWebHostEnvironment"/> from the request's service container.
     /// </summary>
+    /// <param name="ctx">The current http context object.</param>
     /// <returns>Returns an instance of <see cref="Microsoft.AspNetCore.Hosting.IWebHostEnvironment"/>.</returns>
     [<Extension>]
     static member GetWebHostEnvironment(ctx: HttpContext) = ctx.GetService<IWebHostEnvironment>()
@@ -173,6 +174,7 @@ type HttpContextExtensions() =
     /// <summary>
     /// Gets an instance of <see cref="Oxpecker.Serializers.IJsonSerializer"/> from the request's service container.
     /// </summary>
+    /// <param name="ctx">The current http context object.</param>
     /// <returns>Returns an instance of <see cref="Oxpecker.Serializers.IJsonSerializer"/>.</returns>
     [<Extension>]
     static member GetJsonSerializer(ctx: HttpContext) : IJsonSerializer = ctx.GetService<IJsonSerializer>()
@@ -180,9 +182,29 @@ type HttpContextExtensions() =
     /// <summary>
     /// Gets an instance of <see cref="Oxpecker.IModelBinder"/> from the request's service container.
     /// </summary>
+    /// <param name="ctx">The current http context object.</param>
     /// <returns>Returns an instance of <see cref="Oxpecker.IModelBinder"/>.</returns>
     [<Extension>]
     static member GetModelBinder(ctx: HttpContext) : IModelBinder = ctx.GetService<IModelBinder>()
+
+    /// <summary>
+    /// Gets an instance of <see cref="Microsoft.AspNetCore.Antiforgery.AntiforgeryTokenSet"/> from the request's service container.'
+    /// </summary>
+    /// <param name="ctx">The current http context object.</param>
+    /// <returns>Returns an instance of <see cref="Microsoft.AspNetCore.Antiforgery.AntiforgeryTokenSet"/>.</returns>
+    [<Extension>]
+    static member GetAntiforgeryTokens(ctx: HttpContext) =
+        ctx.GetService<IAntiforgery>().GetAndStoreTokens(ctx)
+
+    /// <summary>
+    /// Gets an HTML input object of <see cref=" Oxpecker.ViewEngine.Tags.input"/> type, already filled with the Antiforgery data
+    /// </summary>
+    /// <param name="ctx">The current http context object.</param>
+    /// <returns>Returns an instance of <see cref=" Oxpecker.ViewEngine.Tags.input"/>.</returns>
+    [<Extension>]
+    static member GetAntiforgeryInput(ctx: HttpContext) =
+        let tokens = ctx.GetAntiforgeryTokens()
+        input(type' = "hidden", name = tokens.FormFieldName, value = tokens.RequestToken)
 
     /// <summary>
     /// Sets the HTTP status code of the response.

--- a/src/Oxpecker/HttpContextExtensions.fs
+++ b/src/Oxpecker/HttpContextExtensions.fs
@@ -400,9 +400,7 @@ type HttpContextExtensions() =
             | false ->
                 match f.Error with
                 | null -> ()
-                | err ->
-                    ctx.Response.StatusCode <- StatusCodes.Status403Forbidden
-                    ExceptionDispatchInfo.Throw err
+                | err -> ExceptionDispatchInfo.Throw err
         task {
             try
                 let! form = ctx.Request.ReadFormAsync()

--- a/src/Oxpecker/Middleware.fs
+++ b/src/Oxpecker/Middleware.fs
@@ -2,6 +2,7 @@
 module Oxpecker.Middleware
 
 open System.Runtime.CompilerServices
+open Microsoft.AspNetCore.Antiforgery
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
 open Microsoft.Extensions.DependencyInjection
@@ -15,14 +16,22 @@ type ApplicationBuilderExtensions() =
     /// </summary>
     [<Extension>]
     static member UseOxpecker(builder: IApplicationBuilder, endpoints: Endpoint seq) =
-        builder.UseEndpoints(fun builder -> builder.MapOxpeckerEndpoints endpoints)
+        let addAntiforgery =
+            match builder.ApplicationServices.GetService(typeof<IAntiforgery>) with
+            | null -> false
+            | _ -> true
+        builder.UseEndpoints(_.MapOxpeckerEndpoints(endpoints, addAntiforgery))
 
     /// <summary>
     /// Uses ASP.NET Core's Endpoint Routing middleware to register single Oxpecker endpoint.
     /// </summary>
     [<Extension>]
     static member UseOxpecker(builder: IApplicationBuilder, endpoint: Endpoint) =
-        builder.UseEndpoints(fun builder -> builder.MapOxpeckerEndpoint endpoint)
+        let addAntiforgery =
+            match builder.ApplicationServices.GetService(typeof<IAntiforgery>) with
+            | null -> false
+            | _ -> true
+        builder.UseEndpoints(_.MapOxpeckerEndpoint(endpoint, addAntiforgery))
 
 type ServiceCollectionExtensions() =
     /// <summary>

--- a/src/Oxpecker/README.md
+++ b/src/Oxpecker/README.md
@@ -49,7 +49,9 @@ An in depth functional reference to all of Oxpecker's features.
     - [File Upload](#file-upload)
     - [WebSockets](#websockets)
     - [Grpc](#grpc)
-    - [Authentication and Authorization](#authentication-and-authorization)
+    - [Security](#security)
+      - [Authentication and Authorization](#authentication-and-authorization)
+      - [CSRF protection](#csrf-protection)
     - [Conditional Requests](#conditional-requests)
     - [Response Writing](#response-writing)
       - [Writing Bytes](#writing-bytes)
@@ -1174,17 +1176,19 @@ let main args =
     0
 ```
 
-### Authentication and Authorization
+### Security
 
-Oxpecker's security model is the same as [Minimal API security model](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/security), please make sure you are very familiar with it.
-The main difference is that in Oxpecker you can conveniently call `configureEndpoint _.RequireAuthorization` on both a single endpoint and a group of endpoints.
+Oxpecker's security model is built on top of the ASP.NET Core security model and is very similar to the Minimal API's one, so make sure you are familiar with it.
+
+#### Authentication and Authorization
+
+Oxpecker's auth works just like in [Minimal APIs](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/security).
+To protect endpoints, call `configureEndpoint _.RequireAuthorization` on a single endpoint or a group of endpoints.
 ```fsharp
 let webApp = [
     // single endpoint
     route "/" (text "Hello World")
-        |> configureEndpoint
-            _.DisableAntiforgery()
-             .RequireAuthorization()
+        |> configureEndpoint _.RequireAuthorization()
     // endpoint group
     GET [
         route "/index" <| text "index"
@@ -1194,6 +1198,10 @@ let webApp = [
         )
 ]
 ```
+#### CSRF protection
+
+[TODO](https://learn.microsoft.com/en-us/aspnet/core/security/anti-request-forgery#antiforgery-with-minimal-apis)
+
 ### Conditional Requests
 
 Conditional HTTP headers (e.g., `If-Match`, `If-Modified-Since`, etc.) are a common pattern to improve performance (web caching), to combat the [lost update problem](https://www.w3.org/1999/04/Editing/) or to perform [optimistic concurrency control](https://en.wikipedia.org/wiki/Optimistic_concurrency_control) when a client requests a resource from a web server.

--- a/src/Oxpecker/Routing.fs
+++ b/src/Oxpecker/Routing.fs
@@ -263,23 +263,22 @@ type EndpointRouteBuilderExtensions() =
         match verb with
         | Any ->
             builder.Map(routeTemplate, requestDelegate)
-            |>
-                if addAntiforgery then
-                    _.WithMetadata(RequireAntiforgeryTokenAttribute()) >> configure
-                else
-                    configure
+            |> if addAntiforgery then
+                   _.WithMetadata(RequireAntiforgeryTokenAttribute()) >> configure
+               else
+                   configure
         | Verbs verbs ->
             builder.MapMethods(routeTemplate, verbs |> Seq.map string, requestDelegate)
-            |>
-                if addAntiforgery then
-                    let canHaveForm = verbs |> Seq.exists (
-                        fun verb -> verb = HttpVerb.POST || verb = HttpVerb.PUT || verb = HttpVerb.PATCH)
-                    if canHaveForm then
-                        _.WithMetadata(RequireAntiforgeryTokenAttribute()) >> configure
-                    else
-                        configure
-                else
-                    configure
+            |> if addAntiforgery then
+                   let canHaveForm =
+                       verbs
+                       |> Seq.exists(fun verb -> verb = HttpVerb.POST || verb = HttpVerb.PUT || verb = HttpVerb.PATCH)
+                   if canHaveForm then
+                       _.WithMetadata(RequireAntiforgeryTokenAttribute()) >> configure
+                   else
+                       configure
+               else
+                   configure
         |> ignore
 
     [<Extension>]
@@ -302,9 +301,12 @@ type EndpointRouteBuilderExtensions() =
 
     [<Extension>]
     static member private MapMultiEndpoint
-        (builder: IEndpointRouteBuilder, endpoints: Endpoint seq, parentConfigure: ConfigureEndpoint,
-            addAntiforgery: bool)
-        =
+        (
+            builder: IEndpointRouteBuilder,
+            endpoints: Endpoint seq,
+            parentConfigure: ConfigureEndpoint,
+            addAntiforgery: bool
+        ) =
         for endpoint in endpoints do
             match endpoint with
             | SimpleEndpoint(verb, template, handler, configure) ->
@@ -314,7 +316,9 @@ type EndpointRouteBuilderExtensions() =
             | MultiEndpoint endpoints -> builder.MapMultiEndpoint(endpoints, parentConfigure, addAntiforgery)
 
     [<Extension>]
-    static member internal MapOxpeckerEndpoint(builder: IEndpointRouteBuilder, endpoint: Endpoint, addAntiforgery: bool) =
+    static member internal MapOxpeckerEndpoint
+        (builder: IEndpointRouteBuilder, endpoint: Endpoint, addAntiforgery: bool)
+        =
         match endpoint with
         | SimpleEndpoint(verb, template, handler, configure) ->
             builder.MapSingleEndpoint(verb, template, handler, configure, addAntiforgery)
@@ -323,6 +327,8 @@ type EndpointRouteBuilderExtensions() =
         | MultiEndpoint endpoints -> builder.MapOxpeckerEndpoints(endpoints, addAntiforgery)
 
     [<Extension>]
-    static member internal MapOxpeckerEndpoints(builder: IEndpointRouteBuilder, endpoints: Endpoint seq, addAntiforgery: bool) =
+    static member internal MapOxpeckerEndpoints
+        (builder: IEndpointRouteBuilder, endpoints: Endpoint seq, addAntiforgery: bool)
+        =
         for endpoint in endpoints do
             builder.MapOxpeckerEndpoint(endpoint, addAntiforgery)

--- a/tests/Oxpecker.Tests/Antiforgery.Tests.fs
+++ b/tests/Oxpecker.Tests/Antiforgery.Tests.fs
@@ -1,0 +1,86 @@
+module Oxpecker.Tests.Antiforgery
+
+open System.Collections.Generic
+open System.Net.Http
+open System.Net.Http.Json
+open Microsoft.AspNetCore.Antiforgery
+open Microsoft.AspNetCore.Builder
+open Microsoft.AspNetCore.Hosting
+open Microsoft.AspNetCore.TestHost
+open Microsoft.Extensions.DependencyInjection
+open Microsoft.Net.Http.Headers
+open Oxpecker
+open Xunit
+open FsUnit.Light
+
+module WebApp =
+
+    let notFoundHandler = setStatusCode 404 >=> text "Not found"
+
+    let webApp (endpoints: Endpoint seq) =
+        let builder =
+            WebHostBuilder()
+                .UseKestrel()
+                .Configure(
+                    _.UseRouting()
+                        .UseAntiforgery()
+                        .UseOxpecker(endpoints)
+                        .Run(notFoundHandler)
+                )
+                .ConfigureServices(fun services ->
+                    services
+                        .AddRouting()
+                        .AddAntiforgery()
+                        .AddOxpecker() |> ignore)
+        new TestServer(builder)
+
+
+[<Fact>]
+let ``Request fails when antiforgery token is missing`` () =
+    task {
+        let endpoints = [
+            POST [
+                route "/action" (fun ctx ->
+                    let _ = ctx.BindForm<unit>()
+                    ctx.WriteText "Hello World")
+            ]
+        ]
+        let server = WebApp.webApp endpoints
+        let client = server.CreateClient()
+
+        do! client.PostAsync("/action", null)
+            |> shouldFailTask<AntiforgeryValidationException>
+    }
+
+[<Fact>]
+let ``Request succeeds when antiforgery token is present`` () =
+    task {
+        let endpoints = [
+            GET [
+                route "/action" (fun ctx ->
+                    let tokens = ctx.GetAntiforgeryTokens()
+                    ctx.WriteJson tokens
+                )
+            ]
+            POST [
+                route "/action" (fun ctx -> task {
+                    let! msg = ctx.BindForm<{| Message: string |}>()
+                    return! ctx.WriteText msg.Message
+                })
+            ]
+        ]
+        let server = WebApp.webApp endpoints
+        let client = server.CreateClient()
+        let! response = client.GetAsync("/action")
+        let! tokens = response.Content.ReadFromJsonAsync<AntiforgeryTokenSet>()
+        let cookies = response.Headers.GetValues(HeaderNames.SetCookie)
+        client.DefaultRequestHeaders.Add(HeaderNames.Cookie, cookies)
+        let tokens = nonNull tokens
+        use formContent = new FormUrlEncodedContent([
+            KeyValuePair("Message", "Hi")
+            KeyValuePair(tokens.FormFieldName, tokens.RequestToken)
+        ])
+        let! result = client.PostAsync("/action", formContent)
+        let! text = result.Content.ReadAsStringAsync()
+        text |> shouldEqual "Hi"
+    }

--- a/tests/Oxpecker.Tests/Oxpecker.Tests.fsproj
+++ b/tests/Oxpecker.Tests/Oxpecker.Tests.fsproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Compile Include="Antiforgery.Tests.fs" />
         <Content Include="TestFiles\streaming.txt">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
@@ -27,7 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FsUnit.Light.xUnit" Version="0.2.0" />
+        <PackageReference Include="FsUnit.Light.xUnit" Version="1.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.6" />
         <PackageReference Include="xunit.v3" Version="2.0.3" />

--- a/tests/Oxpecker.ViewEngine.Tests/Oxpecker.ViewEngine.Tests.fsproj
+++ b/tests/Oxpecker.ViewEngine.Tests/Oxpecker.ViewEngine.Tests.fsproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FsUnit.Light.xUnit" Version="0.2.0" />
+        <PackageReference Include="FsUnit.Light.xUnit" Version="1.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.6" />
         <PackageReference Include="xunit.v3" Version="2.0.3" />


### PR DESCRIPTION
- Enabled by default for POST, PUT, PATCH requests if Antiforgery is also enabled (similar to [MiminalApi](https://learn.microsoft.com/en-us/aspnet/core/security/anti-request-forgery?view=aspnetcore-9.0#antiforgery-with-minimal-apis))
- `AntiforgeryValidationException` is thrown on `.BindForm` (similar to MinimalApi's implementation)
- User can disable it using `.DisableAntiforgery` on endpoint
- User can add custom middleware to fail earlier if needed
- User can add CSRF on GET manually by using `_.WithMetadata(RequireAntiforgeryTokenAttribute())` on endpoint
- User should use `ctx.GetAntiforgeryInput()` to add hidden antiforgery input to the form.


Now as there are three different exceptions that Oxpecker throws, I've added default error and not found handlers to use:
```fsharp
app.UseRouting()
    .Use(DefaultHandlers.errorHandler)
    .UseOxpecker(endpoints)
    .Run(DefaultHandlers.notFoundHandler)
```