### PR TITLE
Fix unbounded allocation DoS in collection model binding

### DIFF
--- a/src/Oxpecker/ModelBinder.fs
+++ b/src/Oxpecker/ModelBinder.fs
@@ -14,9 +14,9 @@ type ModelBinderOptions = {
     CultureInfo: CultureInfo
     CaseInsensitiveMatching: bool
     /// Upper bound on the index used when binding indexed collections (e.g. "Items[N].Field").
-    /// Since the index comes straight from the (untrusted) request key, an unbounded value would
-    /// let a single small request drive an arbitrarily large allocation. Indices at or above this
-    /// limit are ignored. Defaults to 1024 (same as ASP.NET Core's MaxModelBindingCollectionSize).
+    /// Since the index comes from the (untrusted) request key, an unbounded value would let a small request drive a large allocation.
+    /// Indices that reach or exceed this limit (or overflow Int32) raise <see cref="MaxCollectionSizeExceededException"/>.
+    /// Defaults to 1024 (same as ASP.NET Core's MaxModelBindingCollectionSize).
     MaxCollectionSize: int
 } with
     static member Default = {

--- a/src/Oxpecker/ModelBinder.fs
+++ b/src/Oxpecker/ModelBinder.fs
@@ -78,7 +78,7 @@ module private DictionaryPool =
                             false
                         else
                             dict.Clear()
-                            dict.Count = 0
+                            true
                 },
                 maximumRetained
             )
@@ -145,80 +145,94 @@ module internal ModelParser =
     /// Parses a "[index]" prefix of the span, returning the index and the position just after ']'.
     /// All span accesses are bounds-checked so that malformed keys (e.g. "[", "[]x") fail the
     /// match instead of throwing. A well-formed index that reaches or exceeds maxCollectionSize
-    /// (or overflows Int32) raises <see cref="MaxCollectionSizeExceededException"/> to bound
-    /// allocations, mirroring ASP.NET Core's MaxModelBindingCollectionSize behaviour.
-    let private tryParseIndex (maxCollectionSize: int) (key: ReadOnlySpan<char>) =
+    /// (or overflows Int32) yields the sentinel index -1 so the caller can reject the request,
+    /// mirroring ASP.NET Core's MaxModelBindingCollectionSize behaviour.
+    let inline private tryParseIndex (maxCollectionSize: int) (key: ReadOnlySpan<char>) =
         if key.Length > 2 && key[0] = '[' then
             let mutable currentIndex = 1
+            let mutable index = 0L
             while currentIndex < key.Length && Char.IsAsciiDigit key[currentIndex] do
+                // Once the value is out of range the accumulation stops, so an absurdly long
+                // digit run cannot overflow Int64 while the shape is still being scanned.
+                if index <= int64 Int32.MaxValue then
+                    index <- index * 10L + int64(key[currentIndex] - '0')
                 currentIndex <- currentIndex + 1
             if
                 currentIndex > 1 // at least one digit
                 && currentIndex < key.Length
                 && key[currentIndex] = ']'
             then
-                // Valid "[index]" syntax: enforce the collection-size limit.
-                // A failed TryParse here means the index overflowed Int32, i.e. far above the limit.
-                match Int32.TryParse(key.Slice(1, currentIndex - 1)) with
-                | true, index when index < maxCollectionSize -> ValueSome(struct (index, currentIndex + 1))
-                | _ -> raise <| MaxCollectionSizeExceededException maxCollectionSize
+                if index < int64 maxCollectionSize then
+                    ValueSome(struct (int index, currentIndex + 1))
+                else
+                    ValueSome(struct (-1, currentIndex + 1))
             else
                 ValueNone
         else
             ValueNone
 
     /// Active pattern for parsing keys in the format "[index].subKey".
+    /// Index -1 means the index reached MaxCollectionSize, regardless of what follows the bracket.
     let private (|IndexAccess|_|) (offset: int) (maxCollectionSize: int) (key: string) =
         let key = key.AsSpan(offset)
         match tryParseIndex maxCollectionSize key with
-        | ValueSome(struct (index, afterBracket)) when afterBracket + 1 < key.Length && key[afterBracket] = '.' ->
+        | ValueSome(struct (index, afterBracket)) when
+            index < 0 || (afterBracket + 1 < key.Length && key[afterBracket] = '.')
+            ->
             ValueSome(struct (index, offset + afterBracket + 1))
         | _ -> ValueNone
 
     /// Active pattern for parsing keys in the format "[index]".
+    /// Index -1 means the index reached MaxCollectionSize, regardless of what follows the bracket.
     let private (|IndexedValue|_|) (offset: int) (maxCollectionSize: int) (key: string) =
         let key = key.AsSpan(offset)
         match tryParseIndex maxCollectionSize key with
-        | ValueSome(struct (index, afterBracket)) when afterBracket = key.Length -> ValueSome index
+        | ValueSome(struct (index, afterBracket)) when index < 0 || afterBracket = key.Length -> ValueSome index
         | _ -> ValueNone
 
     let private (|IndexedValues|) (maxCollectionSize: int) { Offset = offset; Data = data } =
         let matchedData = DictionaryPool.getIndexedValues()
-        try
-            for KeyValue(key, value) in data do
-                match key with
-                | IndexedValue offset maxCollectionSize index ->
+        let mutable overLimit = false
+        for KeyValue(key, value) in data do
+            match key with
+            | IndexedValue offset maxCollectionSize index ->
+                if index < 0 then
+                    overLimit <- true
+                else
                     // Distinct key spellings of the same index (e.g. "[1]" and "[01]") keep the first value.
                     matchedData.TryAdd(index, value) |> ignore
-                | _ -> ()
-            matchedData
-        with _ ->
-            // The index limit check can raise mid-loop; the rented dictionary must still be
-            // returned, otherwise hostile requests would drain the pool.
+            | _ -> ()
+        if overLimit then
+            // The rented dictionary must be returned before rejecting the request,
+            // otherwise hostile requests would drain the pool.
             matchedData.Dispose()
-            reraise()
+            raise <| MaxCollectionSizeExceededException maxCollectionSize
+        matchedData
 
     let private (|ComplexArray|) (maxCollectionSize: int) { Offset = offset; Data = data } =
         let matchedData = DictionaryPool.getIndexed()
-        try
-            for KeyValue(key, value) in data do
-                match key with
-                | IndexAccess offset maxCollectionSize (index, newOffset) ->
+        let mutable overLimit = false
+        for KeyValue(key, value) in data do
+            match key with
+            | IndexAccess offset maxCollectionSize (index, newOffset) ->
+                if index < 0 then
+                    overLimit <- true
+                else
                     match matchedData.TryGetValue(index) with
                     | true, struct (_, subdict) -> subdict[key] <- value
                     | false, _ ->
                         let subdict = DictionaryPool.get()
                         subdict[key] <- value
                         matchedData[index] <- struct (newOffset, subdict)
-                | _ -> ()
-            matchedData
-        with _ ->
-            // The index limit check can raise mid-loop; the rented dictionaries must still be
-            // returned, otherwise hostile requests would drain the pool.
+            | _ -> ()
+        if overLimit then
+            // The rented dictionaries must be returned before rejecting the request,
+            // otherwise hostile requests would drain the pool.
             for struct (_, subdict) in matchedData.Values do
                 subdict.Dispose()
             matchedData.Dispose()
-            reraise()
+            raise <| MaxCollectionSizeExceededException maxCollectionSize
+        matchedData
 
     let private (|ExactMatch|_|) (memberName: string) (ignoreCase: bool) { Offset = offset; Data = data } =
         if offset = 0 && (not ignoreCase) then

--- a/src/Oxpecker/ModelBinder.fs
+++ b/src/Oxpecker/ModelBinder.fs
@@ -3,6 +3,7 @@ namespace Oxpecker
 open System
 open System.Collections.Generic
 open System.Globalization
+open Microsoft.FSharp.Reflection
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Primitives
 open TypeShape.Core.Utils
@@ -253,6 +254,11 @@ module internal ModelParser =
 
     type private Nullable<'T when Struct<'T>> = 'T
 
+    // Concrete stand-in used only to obtain the open generic definition of IParsable<'T>
+    // (via typedefof<IParsable<AnyParsable>>), since typedefof cannot be applied to an
+    // open type argument directly. Any type implementing IParsable<'T> works here.
+    type private AnyParsable = int
+
     type private Parser<'T> = RawData -> 'T
 
     type private MemberSetter<'T> = delegate of RawData * 'T byref -> unit
@@ -269,6 +275,40 @@ module internal ModelParser =
             | ComplexData { Data = rawData } -> $"%A{rawData}"
 
         raise <| NotParsedException(value, typeof<'T>)
+
+    /// Determines whether a collection element of the given type is parsed from a single flat
+    /// value (the indexed "simple value" path, e.g. Items[0]=1) rather than from a nested object.
+    /// Unions qualify because they are always bound from a single case-name string (see the
+    /// FSharpUnion branch in createParser), and wrappers (nullable/option/collections) delegate
+    /// to their element type.
+    let rec private supportsSimpleData (ty: Type) =
+        let nullableType = Nullable.GetUnderlyingType ty
+        if Type.(=)(ty, typeof<string>) || ty.IsEnum then
+            true
+        elif
+            ty.GetInterfaces()
+            |> Array.exists(fun interfaceType ->
+                interfaceType.IsGenericType
+                && Type.(=)(interfaceType.GetGenericTypeDefinition(), typedefof<IParsable<AnyParsable>>))
+        then
+            true
+        elif not(isNull nullableType) then
+            supportsSimpleData(Unchecked.nonNull nullableType)
+        elif ty.IsArray && ty.GetArrayRank() = 1 then
+            supportsSimpleData(ty.GetElementType() |> Unchecked.nonNull)
+        elif ty.IsGenericType then
+            let typeDefinition = ty.GetGenericTypeDefinition()
+            if
+                Type.(=)(typeDefinition, typedefof<option<_>>)
+                || Type.(=)(typeDefinition, typedefof<list<_>>)
+                || Type.(=)(typeDefinition, typedefof<ResizeArray<_>>)
+                || Type.(=)(typeDefinition, typedefof<seq<_>>)
+            then
+                supportsSimpleData(ty.GetGenericArguments()[0])
+            else
+                FSharpType.IsUnion ty
+        else
+            FSharpType.IsUnion ty
 
     let rec private getOrCreateParser<'T> (cache: TypeCache) (options: ModelBinderOptions) : Parser<'T> =
         match cache.TryFind() with
@@ -298,7 +338,7 @@ module internal ModelParser =
                     parser rawData
             res
 
-        if Type.(=)(typeof<'Element>, typeof<string>) then
+        if supportsSimpleData typeof<'Element> then
             function
             | SimpleData values -> parseSimpleValues values
             | ComplexData(IndexedValues options.MaxCollectionSize indexedValues) ->

--- a/src/Oxpecker/ModelBinder.fs
+++ b/src/Oxpecker/ModelBinder.fs
@@ -15,7 +15,7 @@ type ModelBinderOptions = {
     CaseInsensitiveMatching: bool
     /// Upper bound on the index used when binding indexed collections (e.g. "Items[N]" or "Items[N].Field").
     /// The index comes from the (untrusted) request key; indices that reach or exceed this limit
-    /// (or overflow Int32) raise <see cref="MaxCollectionSizeExceededException"/>.
+    /// (or overflow Int32) raise <see cref="ModelBindException"/>.
     /// Defaults to 1024 (same as ASP.NET Core's MaxModelBindingCollectionSize).
     MaxCollectionSize: int
 } with
@@ -123,11 +123,10 @@ type internal UnsupportedTypeException(ty: Type) =
 type internal NotParsedException(value: string, ty: Type) =
     inherit exn($"Could not parse value '%s{value}' to type '{ty}'.")
 
-type MaxCollectionSizeExceededException(maxCollectionSize: int) =
+type internal MaxCollectionSizeExceededException(maxCollectionSize: int) =
     inherit
         exn(
-            $"The collection index reached or exceeded the maximum allowed value of %i{maxCollectionSize}. "
-            + "Increase ModelBinderOptions.MaxCollectionSize if you need to bind larger collections."
+            $"The collection index reached or exceeded the maximum allowed value of %i{maxCollectionSize}."
         )
 
 /// <summary>

--- a/src/Oxpecker/ModelBinder.fs
+++ b/src/Oxpecker/ModelBinder.fs
@@ -148,7 +148,7 @@ module internal ModelParser =
                 currentIndex <- currentIndex + 1
             if
                 currentIndex > 1 // at least one digit
-                && currentIndex + 2 < lastIndex // at least one symbol after '].' (also keeps the reads below in range)
+                && currentIndex + 2 <= lastIndex // at least one symbol after '].' (also keeps the reads below in range)
                 && key[currentIndex] = ']'
                 && key[currentIndex + 1] = '.'
             then

--- a/src/Oxpecker/ModelBinder.fs
+++ b/src/Oxpecker/ModelBinder.fs
@@ -124,10 +124,7 @@ type internal NotParsedException(value: string, ty: Type) =
     inherit exn($"Could not parse value '%s{value}' to type '{ty}'.")
 
 type internal MaxCollectionSizeExceededException(maxCollectionSize: int) =
-    inherit
-        exn(
-            $"The collection index reached or exceeded the maximum allowed value of %i{maxCollectionSize}."
-        )
+    inherit exn($"The collection index reached or exceeded the maximum allowed value of %i{maxCollectionSize}.")
 
 /// <summary>
 /// Module for parsing models from a generic data set.

--- a/src/Oxpecker/ModelBinder.fs
+++ b/src/Oxpecker/ModelBinder.fs
@@ -123,7 +123,7 @@ type internal UnsupportedTypeException(ty: Type) =
 type internal NotParsedException(value: string, ty: Type) =
     inherit exn($"Could not parse value '%s{value}' to type '{ty}'.")
 
-type internal MaxCollectionSizeExceededException(maxCollectionSize: int) =
+type MaxCollectionSizeExceededException(maxCollectionSize: int) =
     inherit
         exn(
             $"The collection index reached or exceeded the maximum allowed value of %i{maxCollectionSize}. "

--- a/src/Oxpecker/ModelBinder.fs
+++ b/src/Oxpecker/ModelBinder.fs
@@ -13,10 +13,16 @@ open TypeShape.Core.Utils
 type ModelBinderOptions = {
     CultureInfo: CultureInfo
     CaseInsensitiveMatching: bool
+    /// Upper bound on the index used when binding indexed collections (e.g. "Items[N].Field").
+    /// Since the index comes straight from the (untrusted) request key, an unbounded value would
+    /// let a single small request drive an arbitrarily large allocation. Indices at or above this
+    /// limit are ignored. Defaults to 1024 (same as ASP.NET Core's MaxModelBindingCollectionSize).
+    MaxCollectionSize: int
 } with
     static member Default = {
         CultureInfo = CultureInfo.InvariantCulture
         CaseInsensitiveMatching = false
+        MaxCollectionSize = 1024
     }
 
 /// <summary>
@@ -109,6 +115,13 @@ type internal UnsupportedTypeException(ty: Type) =
 type internal NotParsedException(value: string, ty: Type) =
     inherit exn($"Could not parse value '%s{value}' to type '{ty}'.")
 
+type internal MaxCollectionSizeExceededException(maxCollectionSize: int) =
+    inherit
+        exn(
+            $"The collection index reached or exceeded the maximum allowed value of %i{maxCollectionSize}. "
+            + "Increase ModelBinderOptions.MaxCollectionSize if you need to bind larger collections."
+        )
+
 /// <summary>
 /// Module for parsing models from a generic data set.
 /// </summary>
@@ -122,32 +135,41 @@ module internal ModelParser =
         else ValueNone
 
     /// Active pattern for parsing keys in the format "[index].subKey".
-    let private (|IndexAccess|_|) (offset: int) (key: string) =
+    /// All span accesses are bounds-checked so that malformed keys (e.g. "[", "[5]") fail the
+    /// match instead of throwing. A well-formed index that reaches or exceeds maxCollectionSize
+    /// (or overflows Int32) raises <see cref="MaxCollectionSizeExceededException"/> to bound
+    /// allocations, mirroring ASP.NET Core's MaxModelBindingCollectionSize behaviour.
+    let private (|IndexAccess|_|) (offset: int) (maxCollectionSize: int) (key: string) =
         let key = key.AsSpan(offset)
-        if key[0] = '[' then
+        if key.Length > 1 && key[0] = '[' then
             let lastIndex = key.Length - 1
             let mutable currentIndex = 1
-            while key[currentIndex] |> Char.IsDigit do
+            while currentIndex < key.Length && Char.IsDigit key[currentIndex] do
                 currentIndex <- currentIndex + 1
             if
                 currentIndex > 1 // at least one digit
+                && currentIndex + 1 < key.Length // key[currentIndex] and key[currentIndex + 1] are in range
                 && key[currentIndex] = ']'
                 && key[currentIndex + 1] = '.'
                 && currentIndex + 2 < lastIndex // at least one symbol after '].'
             then
-                let index = Int32.Parse(key.Slice(1, currentIndex - 1))
-                let newOffset = offset + currentIndex + 2
-                ValueSome(struct (index, newOffset))
+                // Valid "[index].subKey" syntax: enforce the collection-size limit.
+                // A failed TryParse here means the index overflowed Int32, i.e. far above the limit.
+                match Int32.TryParse(key.Slice(1, currentIndex - 1)) with
+                | true, index when index < maxCollectionSize ->
+                    let newOffset = offset + currentIndex + 2
+                    ValueSome(struct (index, newOffset))
+                | _ -> raise <| MaxCollectionSizeExceededException maxCollectionSize
             else
                 ValueNone
         else
             ValueNone
 
-    let private (|ComplexArray|) { Offset = offset; Data = data } =
+    let private (|ComplexArray|) (maxCollectionSize: int) { Offset = offset; Data = data } =
         let matchedData = DictionaryPool.getIndexed()
         for KeyValue(key, value) in data do
             match key with
-            | IndexAccess offset (index, newOffset) ->
+            | IndexAccess offset maxCollectionSize (index, newOffset) ->
                 match matchedData.TryGetValue(index) with
                 | true, struct (_, subdict) -> subdict[key] <- value
                 | false, _ ->
@@ -251,7 +273,7 @@ module internal ModelParser =
                     let rawData = SimpleData(StringValues values[i])
                     parser rawData
             res
-        | ComplexData(ComplexArray indexedDicts) ->
+        | ComplexData(ComplexArray options.MaxCollectionSize indexedDicts) ->
             use indexedDicts = indexedDicts
             let res = ResizeArray()
             for i in indexedDicts.Keys do

--- a/src/Oxpecker/ModelBinder.fs
+++ b/src/Oxpecker/ModelBinder.fs
@@ -3,7 +3,6 @@ namespace Oxpecker
 open System
 open System.Collections.Generic
 open System.Globalization
-open Microsoft.FSharp.Reflection
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Primitives
 open TypeShape.Core.Utils
@@ -15,8 +14,8 @@ type ModelBinderOptions = {
     CultureInfo: CultureInfo
     CaseInsensitiveMatching: bool
     /// Upper bound on the index used when binding indexed collections (e.g. "Items[N]" or "Items[N].Field").
-    /// Since the index comes from the (untrusted) request key, an unbounded value would let a small request drive a large allocation.
-    /// Indices that reach or exceed this limit (or overflow Int32) raise <see cref="MaxCollectionSizeExceededException"/>.
+    /// The index comes from the (untrusted) request key; indices that reach or exceed this limit
+    /// (or overflow Int32) raise <see cref="MaxCollectionSizeExceededException"/>.
     /// Defaults to 1024 (same as ASP.NET Core's MaxModelBindingCollectionSize).
     MaxCollectionSize: int
 } with
@@ -61,6 +60,10 @@ module private DictionaryPool =
     open Microsoft.Extensions.ObjectPool
 
     let private maximumRetained = Environment.ProcessorCount * 2
+    /// Dictionaries grown by a single large request are dropped instead of pooled:
+    /// Clear() keeps the grown bucket arrays, so retaining them would pin that
+    /// capacity in the pool for the process lifetime.
+    let private maximumRetainedCount = 256
 
     type private DictionaryPool<'Key, 'Value when 'Key: not null and 'Key: equality>() as that =
         inherit
@@ -71,8 +74,11 @@ module private DictionaryPool =
                             member this.Dispose() = that.Return(this)
                         }
                     member _.Return(dict) =
-                        dict.Clear()
-                        dict.Count = 0
+                        if dict.Count > maximumRetainedCount then
+                            false
+                        else
+                            dict.Clear()
+                            dict.Count = 0
                 },
                 maximumRetained
             )
@@ -136,73 +142,83 @@ module internal ModelParser =
         elif rawValue.Count = 1 then ValueSome rawValue[0]
         else ValueNone
 
-    /// Active pattern for parsing keys in the format "[index].subKey".
-    /// All span accesses are bounds-checked so that malformed keys (e.g. "[", "[5]") fail the
+    /// Parses a "[index]" prefix of the span, returning the index and the position just after ']'.
+    /// All span accesses are bounds-checked so that malformed keys (e.g. "[", "[]x") fail the
     /// match instead of throwing. A well-formed index that reaches or exceeds maxCollectionSize
     /// (or overflows Int32) raises <see cref="MaxCollectionSizeExceededException"/> to bound
     /// allocations, mirroring ASP.NET Core's MaxModelBindingCollectionSize behaviour.
-    let private (|IndexAccess|_|) (offset: int) (maxCollectionSize: int) (key: string) =
-        let key = key.AsSpan(offset)
-        if key.Length > 1 && key[0] = '[' then
-            let lastIndex = key.Length - 1
+    let private tryParseIndex (maxCollectionSize: int) (key: ReadOnlySpan<char>) =
+        if key.Length > 2 && key[0] = '[' then
             let mutable currentIndex = 1
             while currentIndex < key.Length && Char.IsAsciiDigit key[currentIndex] do
                 currentIndex <- currentIndex + 1
             if
                 currentIndex > 1 // at least one digit
-                && currentIndex + 2 <= lastIndex // at least one symbol after '].' (also keeps the reads below in range)
+                && currentIndex < key.Length
                 && key[currentIndex] = ']'
-                && key[currentIndex + 1] = '.'
             then
-                // Valid "[index].subKey" syntax: enforce the collection-size limit.
+                // Valid "[index]" syntax: enforce the collection-size limit.
                 // A failed TryParse here means the index overflowed Int32, i.e. far above the limit.
                 match Int32.TryParse(key.Slice(1, currentIndex - 1)) with
-                | true, index when index < maxCollectionSize ->
-                    let newOffset = offset + currentIndex + 2
-                    ValueSome(struct (index, newOffset))
+                | true, index when index < maxCollectionSize -> ValueSome(struct (index, currentIndex + 1))
                 | _ -> raise <| MaxCollectionSizeExceededException maxCollectionSize
             else
                 ValueNone
         else
             ValueNone
+
+    /// Active pattern for parsing keys in the format "[index].subKey".
+    let private (|IndexAccess|_|) (offset: int) (maxCollectionSize: int) (key: string) =
+        let key = key.AsSpan(offset)
+        match tryParseIndex maxCollectionSize key with
+        | ValueSome(struct (index, afterBracket)) when afterBracket + 1 < key.Length && key[afterBracket] = '.' ->
+            ValueSome(struct (index, offset + afterBracket + 1))
+        | _ -> ValueNone
 
     /// Active pattern for parsing keys in the format "[index]".
     let private (|IndexedValue|_|) (offset: int) (maxCollectionSize: int) (key: string) =
         let key = key.AsSpan(offset)
-        if key.Length > 2 && key[0] = '[' then
-            let mutable currentIndex = 1
-            while currentIndex < key.Length && Char.IsAsciiDigit key[currentIndex] do
-                currentIndex <- currentIndex + 1
-            if currentIndex > 1 && currentIndex = key.Length - 1 && key[currentIndex] = ']' then
-                match Int32.TryParse(key.Slice(1, currentIndex - 1)) with
-                | true, index when index < maxCollectionSize -> ValueSome index
-                | _ -> raise <| MaxCollectionSizeExceededException maxCollectionSize
-            else
-                ValueNone
-        else
-            ValueNone
+        match tryParseIndex maxCollectionSize key with
+        | ValueSome(struct (index, afterBracket)) when afterBracket = key.Length -> ValueSome index
+        | _ -> ValueNone
 
     let private (|IndexedValues|) (maxCollectionSize: int) { Offset = offset; Data = data } =
         let matchedData = DictionaryPool.getIndexedValues()
-        for KeyValue(key, value) in data do
-            match key with
-            | IndexedValue offset maxCollectionSize index -> matchedData[index] <- value
-            | _ -> ()
-        matchedData
+        try
+            for KeyValue(key, value) in data do
+                match key with
+                | IndexedValue offset maxCollectionSize index ->
+                    // Distinct key spellings of the same index (e.g. "[1]" and "[01]") keep the first value.
+                    matchedData.TryAdd(index, value) |> ignore
+                | _ -> ()
+            matchedData
+        with _ ->
+            // The index limit check can raise mid-loop; the rented dictionary must still be
+            // returned, otherwise hostile requests would drain the pool.
+            matchedData.Dispose()
+            reraise()
 
     let private (|ComplexArray|) (maxCollectionSize: int) { Offset = offset; Data = data } =
         let matchedData = DictionaryPool.getIndexed()
-        for KeyValue(key, value) in data do
-            match key with
-            | IndexAccess offset maxCollectionSize (index, newOffset) ->
-                match matchedData.TryGetValue(index) with
-                | true, struct (_, subdict) -> subdict[key] <- value
-                | false, _ ->
-                    let subdict = DictionaryPool.get()
-                    subdict[key] <- value
-                    matchedData[index] <- struct (newOffset, subdict)
-            | _ -> ()
-        matchedData
+        try
+            for KeyValue(key, value) in data do
+                match key with
+                | IndexAccess offset maxCollectionSize (index, newOffset) ->
+                    match matchedData.TryGetValue(index) with
+                    | true, struct (_, subdict) -> subdict[key] <- value
+                    | false, _ ->
+                        let subdict = DictionaryPool.get()
+                        subdict[key] <- value
+                        matchedData[index] <- struct (newOffset, subdict)
+                | _ -> ()
+            matchedData
+        with _ ->
+            // The index limit check can raise mid-loop; the rented dictionaries must still be
+            // returned, otherwise hostile requests would drain the pool.
+            for struct (_, subdict) in matchedData.Values do
+                subdict.Dispose()
+            matchedData.Dispose()
+            reraise()
 
     let private (|ExactMatch|_|) (memberName: string) (ignoreCase: bool) { Offset = offset; Data = data } =
         if offset = 0 && (not ignoreCase) then
@@ -220,7 +236,10 @@ module internal ModelParser =
             let candidate = memberName.AsSpan()
             while result.IsValueNone && enumerator.MoveNext() do
                 let (KeyValue(key, value)) = enumerator.Current
-                let current = key.AsSpan(offset)
+                let mutable current = key.AsSpan(offset)
+                // At nested levels the key still carries its '.' separator; skip it before comparing.
+                if offset > 0 && current.Length > 0 && current[0] = '.' then
+                    current <- current.Slice(1)
                 if MemoryExtensions.Equals(current, candidate, comparisonType) then
                     result <- ValueSome value
             result
@@ -234,12 +253,22 @@ module internal ModelParser =
             else
                 StringComparison.Ordinal
         for KeyValue(key, value) in data do
-            if key.AsSpan(offset).StartsWith(prefix, comparisonType) then
-                nextOffset <- offset + prefix.Length
-                if key[nextOffset] = '.' then // property access
-                    nextOffset <- nextOffset + 1
-                    matchedData[key] <- value
-                elif key[nextOffset] = '[' then // index access
+            let mutable keySpan = key.AsSpan(offset)
+            let mutable separatorLength = 0
+            // At nested levels the key still carries its '.' separator; skip it before comparing.
+            // The separator is NOT consumed into nextOffset: keys sharing a prefix can mix '.'
+            // and '[' shapes, so consuming it would make the offset depend on key order.
+            if offset > 0 && keySpan.Length > 0 && keySpan[0] = '.' then
+                keySpan <- keySpan.Slice(1)
+                separatorLength <- 1
+            if keySpan.StartsWith(prefix, comparisonType) then
+                let candidateOffset = offset + separatorLength + prefix.Length
+                if
+                    candidateOffset < key.Length
+                    && (key[candidateOffset] = '.' // property access
+                        || key[candidateOffset] = '[') // index access
+                then
+                    nextOffset <- candidateOffset
                     matchedData[key] <- value
         struct (nextOffset, matchedData)
 
@@ -253,11 +282,6 @@ module internal ModelParser =
     type private Enum<'T, 'U when Struct<'T> and 'T: enum<'U>> = 'T
 
     type private Nullable<'T when Struct<'T>> = 'T
-
-    // Concrete stand-in used only to obtain the open generic definition of IParsable<'T>
-    // (via typedefof<IParsable<AnyParsable>>), since typedefof cannot be applied to an
-    // open type argument directly. Any type implementing IParsable<'T> works here.
-    type private AnyParsable = int
 
     type private Parser<'T> = RawData -> 'T
 
@@ -278,37 +302,23 @@ module internal ModelParser =
 
     /// Determines whether a collection element of the given type is parsed from a single flat
     /// value (the indexed "simple value" path, e.g. Items[0]=1) rather than from a nested object.
-    /// Unions qualify because they are always bound from a single case-name string (see the
-    /// FSharpUnion branch in createParser), and wrappers (nullable/option/collections) delegate
+    /// The dispatch deliberately mirrors the simple-data branches of createParser (same TypeShape
+    /// patterns, same order) so the two cannot drift apart. Unions qualify because they are always
+    /// bound from a single case-name string, and wrappers (nullable/option/collections) delegate
     /// to their element type.
-    let rec private supportsSimpleData (ty: Type) =
-        let nullableType = Nullable.GetUnderlyingType ty
-        if Type.(=)(ty, typeof<string>) || ty.IsEnum then
-            true
-        elif
-            ty.GetInterfaces()
-            |> Array.exists(fun interfaceType ->
-                interfaceType.IsGenericType
-                && Type.(=)(interfaceType.GetGenericTypeDefinition(), typedefof<IParsable<AnyParsable>>))
-        then
-            true
-        elif not(isNull nullableType) then
-            supportsSimpleData(Unchecked.nonNull nullableType)
-        elif ty.IsArray && ty.GetArrayRank() = 1 then
-            supportsSimpleData(ty.GetElementType() |> Unchecked.nonNull)
-        elif ty.IsGenericType then
-            let typeDefinition = ty.GetGenericTypeDefinition()
-            if
-                Type.(=)(typeDefinition, typedefof<option<_>>)
-                || Type.(=)(typeDefinition, typedefof<list<_>>)
-                || Type.(=)(typeDefinition, typedefof<ResizeArray<_>>)
-                || Type.(=)(typeDefinition, typedefof<seq<_>>)
-            then
-                supportsSimpleData(ty.GetGenericArguments()[0])
-            else
-                FSharpType.IsUnion ty
-        else
-            FSharpType.IsUnion ty
+    let rec private supportsSimpleData (ty: Type) : bool =
+        match TypeShape.Create ty with
+        | Shape.String -> true
+        | Shape.Parsable _ -> true
+        | Shape.Enum _ -> true
+        | Shape.Nullable _ -> supportsSimpleData(ty.GetGenericArguments()[0])
+        | Shape.FSharpOption shape -> supportsSimpleData shape.Element.Type
+        | Shape.FSharpList shape -> supportsSimpleData shape.Element.Type
+        | Shape.Array shape when shape.Rank = 1 -> supportsSimpleData shape.Element.Type
+        | Shape.ResizeArray shape -> supportsSimpleData shape.Element.Type
+        | Shape.Enumerable shape -> supportsSimpleData shape.Element.Type
+        | Shape.FSharpUnion _ -> true
+        | _ -> false
 
     let rec private getOrCreateParser<'T> (cache: TypeCache) (options: ModelBinderOptions) : Parser<'T> =
         match cache.TryFind() with
@@ -338,32 +348,42 @@ module internal ModelParser =
                     parser rawData
             res
 
+        // Elements are bound sequentially from index 0; binding stops at the first missing
+        // index and later indices are ignored, matching ASP.NET Core's collection binding.
         if supportsSimpleData typeof<'Element> then
             function
             | SimpleData values -> parseSimpleValues values
             | ComplexData(IndexedValues options.MaxCollectionSize indexedValues) ->
                 use indexedValues = indexedValues
-                let res = ResizeArray()
-                for i in indexedValues.Keys do
-                    while i > res.Count - 1 do
-                        res.Add(Unchecked.defaultof<_>)
-                    res[i] <- parser(SimpleData indexedValues[i])
+                let res = ResizeArray(indexedValues.Count)
+                let mutable proceed = true
+                while proceed do
+                    match indexedValues.TryGetValue res.Count with
+                    | true, values ->
+                        // A multi-valued index (e.g. the checkbox + hidden-input fallback idiom)
+                        // binds its first value.
+                        let values = if values.Count > 1 then StringValues values[0] else values
+                        res.Add(parser(SimpleData values))
+                    | false, _ -> proceed <- false
                 res
         else
             function
             | SimpleData values -> parseSimpleValues values
             | ComplexData(ComplexArray options.MaxCollectionSize indexedDicts) ->
                 use indexedDicts = indexedDicts
-                let res = ResizeArray()
-                for i in indexedDicts.Keys do
-                    while i > res.Count - 1 do
-                        res.Add(Unchecked.defaultof<_>)
-                    let struct (offset, dict) = indexedDicts[i]
-                    use dict = dict
-                    res[i] <-
-                        let rawData = ComplexData { Offset = offset; Data = dict }
-                        parser rawData
-                res
+                try
+                    let res = ResizeArray(indexedDicts.Count)
+                    let mutable proceed = true
+                    while proceed do
+                        match indexedDicts.TryGetValue res.Count with
+                        | true, struct (offset, dict) -> res.Add(parser(ComplexData { Offset = offset; Data = dict }))
+                        | false, _ -> proceed <- false
+                    res
+                finally
+                    // Subdictionaries after a gap are never visited, so they are returned
+                    // here rather than one by one inside the loop.
+                    for struct (_, subdict) in indexedDicts.Values do
+                        subdict.Dispose()
 
     and private createMemberParser (ctx: TypeGenerationContext) (options: ModelBinderOptions) : MemberParser<'T> =
         fun shape ->

--- a/src/Oxpecker/ModelBinder.fs
+++ b/src/Oxpecker/ModelBinder.fs
@@ -13,7 +13,7 @@ open TypeShape.Core.Utils
 type ModelBinderOptions = {
     CultureInfo: CultureInfo
     CaseInsensitiveMatching: bool
-    /// Upper bound on the index used when binding indexed collections (e.g. "Items[N].Field").
+    /// Upper bound on the index used when binding indexed collections (e.g. "Items[N]" or "Items[N].Field").
     /// Since the index comes from the (untrusted) request key, an unbounded value would let a small request drive a large allocation.
     /// Indices that reach or exceed this limit (or overflow Int32) raise <see cref="MaxCollectionSizeExceededException"/>.
     /// Defaults to 1024 (same as ASP.NET Core's MaxModelBindingCollectionSize).
@@ -77,6 +77,7 @@ module private DictionaryPool =
             )
 
     let get = DictionaryPool<string, StringValues>().Get
+    let getIndexedValues = DictionaryPool<int, StringValues>().Get
     let getIndexed =
         DictionaryPool<int, struct (int * PooledDictionary<string, StringValues>)>().Get
 
@@ -163,6 +164,30 @@ module internal ModelParser =
                 ValueNone
         else
             ValueNone
+
+    /// Active pattern for parsing keys in the format "[index]".
+    let private (|IndexedValue|_|) (offset: int) (maxCollectionSize: int) (key: string) =
+        let key = key.AsSpan(offset)
+        if key.Length > 2 && key[0] = '[' then
+            let mutable currentIndex = 1
+            while currentIndex < key.Length && Char.IsAsciiDigit key[currentIndex] do
+                currentIndex <- currentIndex + 1
+            if currentIndex > 1 && currentIndex = key.Length - 1 && key[currentIndex] = ']' then
+                match Int32.TryParse(key.Slice(1, currentIndex - 1)) with
+                | true, index when index < maxCollectionSize -> ValueSome index
+                | _ -> raise <| MaxCollectionSizeExceededException maxCollectionSize
+            else
+                ValueNone
+        else
+            ValueNone
+
+    let private (|IndexedValues|) (maxCollectionSize: int) { Offset = offset; Data = data } =
+        let matchedData = DictionaryPool.getIndexedValues()
+        for KeyValue(key, value) in data do
+            match key with
+            | IndexedValue offset maxCollectionSize index -> matchedData[index] <- value
+            | _ -> ()
+        matchedData
 
     let private (|ComplexArray|) (maxCollectionSize: int) { Offset = offset; Data = data } =
         let matchedData = DictionaryPool.getIndexed()
@@ -264,26 +289,41 @@ module internal ModelParser =
         (options: ModelBinderOptions)
         : Parser<'Element seq> =
         let parser = getOrCacheParser<'Element> ctx options
-        function
-        | SimpleData values ->
+
+        let parseSimpleValues (values: StringValues) =
             let res = Array.zeroCreate(values.Count)
             for i in 0 .. values.Count - 1 do
                 res[i] <-
                     let rawData = SimpleData(StringValues values[i])
                     parser rawData
             res
-        | ComplexData(ComplexArray options.MaxCollectionSize indexedDicts) ->
-            use indexedDicts = indexedDicts
-            let res = ResizeArray()
-            for i in indexedDicts.Keys do
-                while i > res.Count - 1 do
-                    res.Add(Unchecked.defaultof<_>)
-                let struct (offset, dict) = indexedDicts[i]
-                use dict = dict
-                res[i] <-
-                    let rawData = ComplexData { Offset = offset; Data = dict }
-                    parser rawData
-            res
+
+        if Type.(=)(typeof<'Element>, typeof<string>) then
+            function
+            | SimpleData values -> parseSimpleValues values
+            | ComplexData(IndexedValues options.MaxCollectionSize indexedValues) ->
+                use indexedValues = indexedValues
+                let res = ResizeArray()
+                for i in indexedValues.Keys do
+                    while i > res.Count - 1 do
+                        res.Add(Unchecked.defaultof<_>)
+                    res[i] <- parser(SimpleData indexedValues[i])
+                res
+        else
+            function
+            | SimpleData values -> parseSimpleValues values
+            | ComplexData(ComplexArray options.MaxCollectionSize indexedDicts) ->
+                use indexedDicts = indexedDicts
+                let res = ResizeArray()
+                for i in indexedDicts.Keys do
+                    while i > res.Count - 1 do
+                        res.Add(Unchecked.defaultof<_>)
+                    let struct (offset, dict) = indexedDicts[i]
+                    use dict = dict
+                    res[i] <-
+                        let rawData = ComplexData { Offset = offset; Data = dict }
+                        parser rawData
+                res
 
     and private createMemberParser (ctx: TypeGenerationContext) (options: ModelBinderOptions) : MemberParser<'T> =
         fun shape ->

--- a/src/Oxpecker/ModelBinder.fs
+++ b/src/Oxpecker/ModelBinder.fs
@@ -144,14 +144,13 @@ module internal ModelParser =
         if key.Length > 1 && key[0] = '[' then
             let lastIndex = key.Length - 1
             let mutable currentIndex = 1
-            while currentIndex < key.Length && Char.IsDigit key[currentIndex] do
+            while currentIndex < key.Length && Char.IsAsciiDigit key[currentIndex] do
                 currentIndex <- currentIndex + 1
             if
                 currentIndex > 1 // at least one digit
-                && currentIndex + 1 < key.Length // key[currentIndex] and key[currentIndex + 1] are in range
+                && currentIndex + 2 < lastIndex // at least one symbol after '].' (also keeps the reads below in range)
                 && key[currentIndex] = ']'
                 && key[currentIndex + 1] = '.'
-                && currentIndex + 2 < lastIndex // at least one symbol after '].'
             then
                 // Valid "[index].subKey" syntax: enforce the collection-size limit.
                 // A failed TryParse here means the index overflowed Int32, i.e. far above the limit.

--- a/src/Oxpecker/Oxpecker.fsproj
+++ b/src/Oxpecker/Oxpecker.fsproj
@@ -22,9 +22,9 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <Version>2.0.1</Version>
-        <PackageVersion>2.0.1</PackageVersion>
-        <PackageReleaseNotes>Included documentation file in the package</PackageReleaseNotes>
+        <Version>2.1.0</Version>
+        <PackageVersion>2.1.0</PackageVersion>
+        <PackageReleaseNotes>MaxCollectionSize model binder option introduced</PackageReleaseNotes>
     </PropertyGroup>
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/Oxpecker/Oxpecker.fsproj
+++ b/src/Oxpecker/Oxpecker.fsproj
@@ -24,7 +24,7 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Version>2.1.0</Version>
         <PackageVersion>2.1.0</PackageVersion>
-        <PackageReleaseNotes>MaxCollectionSize model binder option introduced</PackageReleaseNotes>
+        <PackageReleaseNotes>MaxCollectionSize model binder option introduced.</PackageReleaseNotes>
     </PropertyGroup>
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/Oxpecker/README.md
+++ b/src/Oxpecker/README.md
@@ -850,6 +850,8 @@ The underlying JSON serializer can be configured as a dependency during applicat
 
 The `BindForm<'T>` extension method binds form data to an object of type `'T`:
 
+String collections accept repeated keys (`tags=dotnet&tags=mvc&tags=api`) and indexed keys (`tags[0]=dotnet&tags[1]=mvc&tags[2]=api`).
+
 ```fsharp
 [<CLIMutable>]
 type Car = {
@@ -921,6 +923,8 @@ let configureServices (services : IServiceCollection) =
 #### Binding Query Strings
 
 The `BindQuery<'T>` extension method binds query string parameters to an object of type `'T`:
+
+String collections accept the same repeated and indexed key formats as form binding.
 
 ```fsharp
 [<CLIMutable>]

--- a/src/Oxpecker/README.md
+++ b/src/Oxpecker/README.md
@@ -850,7 +850,7 @@ The underlying JSON serializer can be configured as a dependency during applicat
 
 The `BindForm<'T>` extension method binds form data to an object of type `'T`:
 
-Collections of supported values, including strings, numbers, booleans, enums, nullable values, and options, accept repeated keys (`tags=dotnet&tags=mvc&tags=api`) and indexed keys (`tags[0]=dotnet&tags[1]=mvc&tags[2]=api`).
+Collections of supported values, including strings, numbers, booleans, enums, nullable values, and options, accept repeated keys (`tags=dotnet&tags=mvc&tags=api`) and indexed keys (`tags[0]=dotnet&tags[1]=mvc&tags[2]=api`). Indexed keys are bound sequentially from index 0 and, as in ASP.NET Core, binding stops at the first missing index (values after a gap are ignored). When the same index is sent multiple times (e.g. the checkbox + hidden-input fallback idiom) the first value wins.
 
 ```fsharp
 [<CLIMutable>]

--- a/src/Oxpecker/README.md
+++ b/src/Oxpecker/README.md
@@ -850,7 +850,7 @@ The underlying JSON serializer can be configured as a dependency during applicat
 
 The `BindForm<'T>` extension method binds form data to an object of type `'T`:
 
-String collections accept repeated keys (`tags=dotnet&tags=mvc&tags=api`) and indexed keys (`tags[0]=dotnet&tags[1]=mvc&tags[2]=api`).
+Collections of supported values, including strings, numbers, booleans, enums, nullable values, and options, accept repeated keys (`tags=dotnet&tags=mvc&tags=api`) and indexed keys (`tags[0]=dotnet&tags[1]=mvc&tags[2]=api`).
 
 ```fsharp
 [<CLIMutable>]
@@ -924,7 +924,7 @@ let configureServices (services : IServiceCollection) =
 
 The `BindQuery<'T>` extension method binds query string parameters to an object of type `'T`:
 
-String collections accept the same repeated and indexed key formats as form binding.
+Collections accept the same repeated and indexed key formats as form binding.
 
 ```fsharp
 [<CLIMutable>]

--- a/src/Oxpecker/README.md
+++ b/src/Oxpecker/README.md
@@ -850,8 +850,6 @@ The underlying JSON serializer can be configured as a dependency during applicat
 
 The `BindForm<'T>` extension method binds form data to an object of type `'T`:
 
-Collections of supported values, including strings, numbers, booleans, enums, nullable values, and options, accept repeated keys (`tags=dotnet&tags=mvc&tags=api`) and indexed keys (`tags[0]=dotnet&tags[1]=mvc&tags[2]=api`). Indexed keys are bound sequentially from index 0 and, as in ASP.NET Core, binding stops at the first missing index (values after a gap are ignored). When the same index is sent multiple times (e.g. the checkbox + hidden-input fallback idiom) the first value wins.
-
 ```fsharp
 [<CLIMutable>]
 type Car = {
@@ -907,6 +905,8 @@ let webApp = [
 ```
 
 Just like in the previous examples the record type must be decorated with the `[<CLIMutable>]` attribute in order for the model binding to work.
+
+Collections of supported values, including strings, numbers, booleans, enums, nullable values, and options, accept repeated keys (`tags=dotnet&tags=mvc&tags=api`) and indexed keys (`tags[0]=dotnet&tags[1]=mvc&tags[2]=api`). Indexed keys are bound sequentially from index 0 and, as in ASP.NET Core, binding stops at the first missing index (values after a gap are ignored). When the same index is sent multiple times (e.g. the checkbox + hidden-input fallback idiom) the first value wins. Indexed collection binding is capped by `ModelBinderOptions.MaxCollectionSize` (default 1024); indices that reach or exceed the limit fail binding.
 
 The underlying model binder is configured as a dependency during application startup:
 

--- a/tests/Oxpecker.Tests/HttpContextExtensions.Tests.fs
+++ b/tests/Oxpecker.Tests/HttpContextExtensions.Tests.fs
@@ -2,6 +2,7 @@
 
 open System
 open System.IO
+open System.Text
 open Microsoft.AspNetCore.Http
 open Microsoft.AspNetCore.WebUtilities
 open Microsoft.Extensions.DependencyInjection
@@ -12,6 +13,17 @@ open Oxpecker
 
 
 #nowarn "3391"
+
+type StringCollectionModel = { Tags: string list }
+
+let private createFormContext (body: string) =
+    let ctx = DefaultHttpContext()
+    ctx.Request.Body <- new MemoryStream(Encoding.UTF8.GetBytes body)
+    ctx.Request.ContentType <- "application/x-www-form-urlencoded"
+    let services = ServiceCollection()
+    services.AddSingleton<IModelBinder>(ModelBinder()) |> ignore
+    ctx.RequestServices <- services.BuildServiceProvider()
+    ctx
 
 [<Fact>]
 let ``GetRequestUrl returns entire URL of the HTTP request`` () =
@@ -50,6 +62,55 @@ let ``TryGetQueryStringValue during HTTP GET request with query string returns c
     let result = ctx.TryGetQueryValue "BirthDate"
 
     result |> shouldEqual(Some "1990-04-20")
+
+[<Fact>]
+let ``ReadFormAsync groups repeated string collection values`` () =
+    task {
+        let ctx = createFormContext "tags=dotnet&tags=mvc&tags=api"
+
+        let! form = ctx.Request.ReadFormAsync()
+
+        form.Keys |> Seq.toList |> shouldEqual [ "tags" ]
+        form["tags"] |> Seq.toList |> shouldEqual [ "dotnet"; "mvc"; "api" ]
+    }
+
+[<Fact>]
+let ``ReadFormAsync preserves indexed string collection keys`` () =
+    task {
+        let ctx = createFormContext "tags[0]=dotnet&tags[1]=mvc&tags[2]=api"
+
+        let! form = ctx.Request.ReadFormAsync()
+
+        form.Keys |> Set.ofSeq |> shouldEqual(set [ "tags[0]"; "tags[1]"; "tags[2]" ])
+        form["tags[0]"] |> string |> shouldEqual "dotnet"
+        form["tags[1]"] |> string |> shouldEqual "mvc"
+        form["tags[2]"] |> string |> shouldEqual "api"
+    }
+
+[<Fact>]
+let ``BindForm binds repeated and indexed string collections`` () =
+    task {
+        let repeatedContext = createFormContext "Tags=dotnet&Tags=mvc&Tags=api"
+        let indexedContext = createFormContext "Tags[0]=dotnet&Tags[1]=mvc&Tags[2]=api"
+
+        let! repeated = repeatedContext.BindForm<StringCollectionModel>()
+        let! indexed = indexedContext.BindForm<StringCollectionModel>()
+
+        repeated.Tags |> shouldEqual [ "dotnet"; "mvc"; "api" ]
+        indexed.Tags |> shouldEqual repeated.Tags
+    }
+
+[<Fact>]
+let ``BindQuery binds indexed string collections`` () =
+    let ctx = DefaultHttpContext()
+    let services = ServiceCollection()
+    services.AddSingleton<IModelBinder>(ModelBinder()) |> ignore
+    ctx.RequestServices <- services.BuildServiceProvider()
+    ctx.Request.Query <- QueryCollection(QueryHelpers.ParseQuery "?Tags[0]=dotnet&Tags[1]=mvc&Tags[2]=api")
+
+    let result = ctx.BindQuery<StringCollectionModel>()
+
+    result.Tags |> shouldEqual [ "dotnet"; "mvc"; "api" ]
 
 [<Fact>]
 let ``WriteText with HTTP GET should return text in body`` () =

--- a/tests/Oxpecker.Tests/HttpContextExtensions.Tests.fs
+++ b/tests/Oxpecker.Tests/HttpContextExtensions.Tests.fs
@@ -16,6 +16,12 @@ open Oxpecker
 
 type StringCollectionModel = { Tags: string list }
 
+type ScalarCollectionModel = {
+    Counts: int array
+    Ratios: float list
+    Flags: bool seq
+}
+
 let private createFormContext (body: string) =
     let ctx = DefaultHttpContext()
     ctx.Request.Body <- new MemoryStream(Encoding.UTF8.GetBytes body)
@@ -98,6 +104,19 @@ let ``BindForm binds repeated and indexed string collections`` () =
 
         repeated.Tags |> shouldEqual [ "dotnet"; "mvc"; "api" ]
         indexed.Tags |> shouldEqual repeated.Tags
+    }
+
+[<Fact>]
+let ``BindForm binds indexed scalar collections`` () =
+    task {
+        let ctx =
+            createFormContext "Counts[0]=1&Counts[1]=2&Ratios[0]=1.5&Ratios[1]=2.25&Flags[0]=true&Flags[1]=false"
+
+        let! result = ctx.BindForm<ScalarCollectionModel>()
+
+        result.Counts |> shouldEqual [| 1; 2 |]
+        result.Ratios |> shouldEqual [ 1.5; 2.25 ]
+        result.Flags |> shouldEqual(seq [ true; false ])
     }
 
 [<Fact>]

--- a/tests/Oxpecker.Tests/HttpContextExtensions.Tests.fs
+++ b/tests/Oxpecker.Tests/HttpContextExtensions.Tests.fs
@@ -120,6 +120,17 @@ let ``BindForm binds indexed scalar collections`` () =
     }
 
 [<Fact>]
+let ``BindForm binds first value for duplicated collection index`` () =
+    task {
+        // The checkbox + hidden-input fallback idiom: both inputs share the same indexed name.
+        let ctx = createFormContext "Flags[0]=true&Flags[0]=false&Flags[1]=false"
+
+        let! result = ctx.BindForm<ScalarCollectionModel>()
+
+        result.Flags |> shouldEqual(seq [ true; false ])
+    }
+
+[<Fact>]
 let ``BindQuery binds indexed string collections`` () =
     let ctx = DefaultHttpContext()
     let services = ServiceCollection()

--- a/tests/Oxpecker.Tests/ModelParser.Tests.fs
+++ b/tests/Oxpecker.Tests/ModelParser.Tests.fs
@@ -828,9 +828,9 @@ let ``defaultParseModel<Poco> parses valid POCO data`` () =
 [<Fact>]
 let ``parseModel throws when collection index reaches MaxCollectionSize`` () =
     // Without the cap this single key would drive an allocation of ~2 billion elements.
-    let modelData =
-        [ "Children[2000000000].Name", StringValues "x" ] |> toComplexData
-    let result () = defaultParseModel<Model> modelData |> ignore
+    let modelData = [ "Children[2000000000].Name", StringValues "x" ] |> toComplexData
+    let result () =
+        defaultParseModel<Model> modelData |> ignore
     result |> shouldFail<MaxCollectionSizeExceededException>
 
 [<Fact>]
@@ -847,7 +847,10 @@ let ``parseModel binds collection index just below MaxCollectionSize`` () =
 
 [<Fact>]
 let ``parseModel throws for index at a custom MaxCollectionSize`` () =
-    let options = { ModelBinderOptions.Default with MaxCollectionSize = 4 }
+    let options = {
+        ModelBinderOptions.Default with
+            MaxCollectionSize = 4
+    }
     let cache = TypeShape.Core.Utils.TypeCache()
     let modelData = [ "Children[10].Name", StringValues "x" ] |> toComplexData
     let result () =
@@ -856,9 +859,9 @@ let ``parseModel throws for index at a custom MaxCollectionSize`` () =
 
 [<Fact>]
 let ``parseModel throws on index above Int32 max`` () =
-    let modelData =
-        [ "Children[9999999999].Name", StringValues "x" ] |> toComplexData
-    let result () = defaultParseModel<Model> modelData |> ignore
+    let modelData = [ "Children[9999999999].Name", StringValues "x" ] |> toComplexData
+    let result () =
+        defaultParseModel<Model> modelData |> ignore
     result |> shouldFail<MaxCollectionSizeExceededException>
 
 [<Fact>]
@@ -870,5 +873,11 @@ let ``parseModel does not throw on unterminated index key`` () =
 [<Fact>]
 let ``parseModel does not throw on index without subkey`` () =
     let modelData = [ "Children[5]", StringValues "x" ] |> toComplexData
+    let result = defaultParseModel<Model> modelData
+    result.Children |> shouldEqual [||]
+
+[<Fact>]
+let ``parseModel does not throw on unterminated property`` () =
+    let modelData = [ "Children[5].", StringValues "x" ] |> toComplexData
     let result = defaultParseModel<Model> modelData
     result.Children |> shouldEqual [||]

--- a/tests/Oxpecker.Tests/ModelParser.Tests.fs
+++ b/tests/Oxpecker.Tests/ModelParser.Tests.fs
@@ -822,3 +822,53 @@ let ``defaultParseModel<Poco> parses valid POCO data`` () =
     let expected = Poco(Id = 666, Name = "Lorem ipsum", Value = 1_234)
     let result = defaultParseModel<Poco> modelData
     result |> shouldEquivalent expected
+
+// Regression tests for the collection-index binding hardening (unbounded-allocation DoS + malformed keys)
+
+[<Fact>]
+let ``parseModel throws when collection index reaches MaxCollectionSize`` () =
+    // Without the cap this single key would drive an allocation of ~2 billion elements.
+    let modelData =
+        [ "Children[2000000000].Name", StringValues "x" ] |> toComplexData
+    let result () = defaultParseModel<Model> modelData |> ignore
+    result |> shouldFail<MaxCollectionSizeExceededException>
+
+[<Fact>]
+let ``parseModel binds collection index just below MaxCollectionSize`` () =
+    let modelData =
+        [
+            "Children[1023].Name", StringValues "Ali"
+            "Children[1023].Age", StringValues "22"
+        ]
+        |> toComplexData
+    let result = defaultParseModel<Model> modelData
+    result.Children.Length |> shouldEqual 1024
+    result.Children[1023] |> shouldEqual { Name = "Ali"; Age = 22 }
+
+[<Fact>]
+let ``parseModel throws for index at a custom MaxCollectionSize`` () =
+    let options = { ModelBinderOptions.Default with MaxCollectionSize = 4 }
+    let cache = TypeShape.Core.Utils.TypeCache()
+    let modelData = [ "Children[10].Name", StringValues "x" ] |> toComplexData
+    let result () =
+        ModelParser.parseModel<Model> cache options modelData |> ignore
+    result |> shouldFail<MaxCollectionSizeExceededException>
+
+[<Fact>]
+let ``parseModel throws on index above Int32 max`` () =
+    let modelData =
+        [ "Children[9999999999].Name", StringValues "x" ] |> toComplexData
+    let result () = defaultParseModel<Model> modelData |> ignore
+    result |> shouldFail<MaxCollectionSizeExceededException>
+
+[<Fact>]
+let ``parseModel does not throw on unterminated index key`` () =
+    let modelData = [ "Children[", StringValues "x" ] |> toComplexData
+    let result = defaultParseModel<Model> modelData
+    result.Children |> shouldEqual [||]
+
+[<Fact>]
+let ``parseModel does not throw on index without subkey`` () =
+    let modelData = [ "Children[5]", StringValues "x" ] |> toComplexData
+    let result = defaultParseModel<Model> modelData
+    result.Children |> shouldEqual [||]

--- a/tests/Oxpecker.Tests/ModelParser.Tests.fs
+++ b/tests/Oxpecker.Tests/ModelParser.Tests.fs
@@ -19,6 +19,10 @@ type Sex =
     | Male
     | Female
 
+type internal InternalChoice =
+    | ChoiceA
+    | ChoiceB
+
 type Child = { Name: string | null; Age: int }
 
 type Model = {
@@ -117,6 +121,52 @@ let ``parseModel<Model2> handles indexed string array`` () =
     result |> shouldEqual expected
 
 [<Fact>]
+let ``parseModel<Model2> ignores indexed values after a missing index`` () =
+    let modelData =
+        [ "SearchTerms[0]", StringValues "a"; "SearchTerms[5]", StringValues "b" ]
+        |> toComplexData
+    let expected = { SearchTerms = [| "a" |] }
+    let result = defaultParseModel<Model2> modelData
+    result |> shouldEqual expected
+
+[<Fact>]
+let ``parseModel<Model2> binds empty array when the first index is missing`` () =
+    let modelData = [ "SearchTerms[10]", StringValues "a" ] |> toComplexData
+    let expected = { SearchTerms = [||] }
+    let result = defaultParseModel<Model2> modelData
+    result |> shouldEqual expected
+
+[<Fact>]
+let ``parseModel<Model2> binds first value for a multi-valued index`` () =
+    // Duplicated key (e.g. "SearchTerms[0]=a&SearchTerms[0]=b") arrives merged into one StringValues.
+    let modelData = [ "SearchTerms[0]", StringValues [| "a"; "b" |] ] |> toComplexData
+    let expected = { SearchTerms = [| "a" |] }
+    let result = defaultParseModel<Model2> modelData
+    result |> shouldEqual expected
+
+[<Fact>]
+let ``parseModel<Model2> binds first value for distinct spellings of the same index`` () =
+    let modelData =
+        [
+            "SearchTerms[0]", StringValues "z"
+            "SearchTerms[1]", StringValues "a"
+            "SearchTerms[01]", StringValues "b"
+        ]
+        |> toComplexData
+    let expected = { SearchTerms = [| "z"; "a" |] }
+    let result = defaultParseModel<Model2> modelData
+    result |> shouldEqual expected
+
+[<Fact>]
+let ``parseModel<Model2> ignores non-indexed subkeys regardless of key order`` () =
+    let data = [ "SearchTerms[0]", StringValues "a"; "SearchTerms.x", StringValues "1" ]
+    let expected = { SearchTerms = [| "a" |] }
+
+    defaultParseModel<Model2>(toComplexData data) |> shouldEqual expected
+
+    defaultParseModel<Model2>(toComplexData(List.rev data)) |> shouldEqual expected
+
+[<Fact>]
 let ``defaultParseModel<Model> parses complete model data correctly`` () =
     let id = Guid.NewGuid()
     let modelData =
@@ -212,11 +262,8 @@ let ``defaultParseModel<Model> handles missing array items`` () =
         Sex = Female
         BirthDate = DateTime(1986, 12, 29)
         Nicknames = None
-        Children = [|
-            { Name = "Hamed"; Age = 32 }
-            Unchecked.defaultof<_>
-            { Name = "Gholi"; Age = 44 }
-        |]
+        // Binding stops at the first missing index, so Children[2] is ignored.
+        Children = [| { Name = "Hamed"; Age = 32 } |]
     }
     let result = defaultParseModel<Model> modelData
     result |> shouldEqual expected
@@ -597,6 +644,22 @@ let ``defaultParseModel parses indexed collections of supported scalar types`` (
     |> shouldEqual [| Female; Male |]
 
 [<Fact>]
+let ``defaultParseModel stops binding at the first missing index`` () =
+    defaultParseModel<int array>(toComplexData [ "[0]", StringValues "1"; "[2]", StringValues "2" ])
+    |> shouldEqual [| 1 |]
+
+    defaultParseModel<string array>(toComplexData [ "[1]", StringValues "b" ])
+    |> shouldEqual [||]
+
+[<Fact>]
+let ``defaultParseModel parses indexed collection of internal union type`` () =
+    let modelData =
+        [ "[0]", StringValues "ChoiceB"; "[1]", StringValues "ChoiceA" ]
+        |> toComplexData
+    let result = defaultParseModel<InternalChoice array> modelData
+    result |> shouldEqual [| ChoiceB; ChoiceA |]
+
+[<Fact>]
 let ``defaultParseModel<BookType> parses a valid enum value 'Paperback'`` () =
     let modelData = "Paperback" |> StringValues |> SimpleData
     let expected = BookType.Paperback
@@ -681,7 +744,7 @@ type Bar = { Bar: string | null; Baz: Baz | null }
 type Foo = { Foo: string; Bars: Bar option seq }
 
 [<Fact>]
-let ``defaultParseModel<Foo> parses data with non-sequential index elements`` () =
+let ``defaultParseModel<Foo> stops binding at the first missing index`` () =
     let modelData =
         [
             "Bars[2].Bar", StringValues "Bar"
@@ -700,7 +763,31 @@ let ``defaultParseModel<Foo> parses data with non-sequential index elements`` ()
                     Value = Nullable 0
                 }
             }
-            None
+        |]
+    }
+    let result = defaultParseModel<Foo> modelData
+    result |> shouldEquivalent expected
+
+[<Fact>]
+let ``defaultParseModel<Foo> parses out-of-order sequential index elements`` () =
+    let modelData =
+        [
+            "Bars[1].Bar", StringValues "Bar"
+            "Bars[0].Baz.Name", StringValues "abc"
+            "Bars[0].Baz.Value", StringValues "0"
+            "Bars[1].Baz.Value", StringValues "1"
+        ]
+        |> toComplexData
+    let expected = {
+        Foo = Unchecked.defaultof<_>
+        Bars = [|
+            Some {
+                Bar = null
+                Baz = {
+                    Name = Some "abc"
+                    Value = Nullable 0
+                }
+            }
             Some {
                 Bar = "Bar"
                 Baz = { Name = None; Value = Nullable 1 }
@@ -804,15 +891,14 @@ type AnonymousType2 = {|
 let ``defaultParseModel<AnonymousType2> parses deeply nested anonymous type data`` () =
     let modelData =
         [
-            "Values[2].Value.Values[2].Value.Name", StringValues "foo"
-            "Values[2].Value.Values[0].Value.Id", StringValues "111"
-            "Values[1].Value.Values[0].Value.Name", StringValues "bar"
-            "Values[2].Value.Values[2].Value.Id", StringValues "222"
+            "Values[1].Value.Values[1].Value.Name", StringValues "foo"
+            "Values[1].Value.Values[0].Value.Id", StringValues "111"
+            "Values[0].Value.Values[0].Value.Name", StringValues "bar"
+            "Values[1].Value.Values[1].Value.Id", StringValues "222"
         ]
         |> toComplexData
     let expected: AnonymousType2 = {|
         Values = [|
-            Unchecked.defaultof<_>
             {|
                 Value = {|
                     Values = [| {| Value = {| Id = 0; Name = "bar" |} |} |]
@@ -824,7 +910,6 @@ let ``defaultParseModel<AnonymousType2> parses deeply nested anonymous type data
                         {|
                             Value = {| Id = 111; Name = null |}
                         |}
-                        Unchecked.defaultof<_>
                         {|
                             Value = {| Id = 222; Name = "foo" |}
                         |}
@@ -887,7 +972,36 @@ let ``parseModel throws when indexed string collection reaches MaxCollectionSize
     result |> shouldFail<MaxCollectionSizeExceededException>
 
 [<Fact>]
+let ``parseModel throws when simple-element index with subkey exceeds MaxCollectionSize`` () =
+    // The limit is enforced for any well-formed "[N]" segment, even when the key shape
+    // ("[N].subKey" on a simple-element collection) won't bind anything.
+    let modelData = [ "SearchTerms[2000000000].x", StringValues "x" ] |> toComplexData
+    let result () =
+        defaultParseModel<Model2> modelData |> ignore
+    result |> shouldFail<MaxCollectionSizeExceededException>
+
+[<Fact>]
+let ``parseModel throws when complex-element index without subkey exceeds MaxCollectionSize`` () =
+    let modelData = [ "Children[2000000000]", StringValues "x" ] |> toComplexData
+    let result () =
+        defaultParseModel<Model> modelData |> ignore
+    result |> shouldFail<MaxCollectionSizeExceededException>
+
+[<Fact>]
 let ``parseModel binds collection index just below MaxCollectionSize`` () =
+    let modelData =
+        [
+            for i in 0..1023 do
+                $"Children[%i{i}].Name", StringValues "Ali"
+                $"Children[%i{i}].Age", StringValues(string i)
+        ]
+        |> toComplexData
+    let result = defaultParseModel<Model> modelData
+    result.Children.Length |> shouldEqual 1024
+    result.Children[1023] |> shouldEqual { Name = "Ali"; Age = 1023 }
+
+[<Fact>]
+let ``parseModel ignores index just below MaxCollectionSize when earlier indices are missing`` () =
     let modelData =
         [
             "Children[1023].Name", StringValues "Ali"
@@ -895,8 +1009,7 @@ let ``parseModel binds collection index just below MaxCollectionSize`` () =
         ]
         |> toComplexData
     let result = defaultParseModel<Model> modelData
-    result.Children.Length |> shouldEqual 1024
-    result.Children[1023] |> shouldEqual { Name = "Ali"; Age = 22 }
+    result.Children |> shouldEqual [||]
 
 [<Fact>]
 let ``parseModel throws for index at a custom MaxCollectionSize`` () =

--- a/tests/Oxpecker.Tests/ModelParser.Tests.fs
+++ b/tests/Oxpecker.Tests/ModelParser.Tests.fs
@@ -570,6 +570,33 @@ type BookType =
     | EBook = 3
 
 [<Fact>]
+let ``defaultParseModel parses indexed collections of supported scalar types`` () =
+    let indexedData (values: string list) =
+        values
+        |> List.mapi(fun index value -> $"[%i{index}]", StringValues value)
+        |> toComplexData
+
+    defaultParseModel<int array>(indexedData [ "1"; "2" ]) |> shouldEqual [| 1; 2 |]
+
+    defaultParseModel<float list>(indexedData [ "1.5"; "2.25" ])
+    |> shouldEqual [ 1.5; 2.25 ]
+
+    defaultParseModel<ResizeArray<bool>>(indexedData [ "true"; "FALSE" ])
+    |> shouldEqual(ResizeArray [ true; false ])
+
+    defaultParseModel<BookType seq>(indexedData [ "EBook"; "Paperback" ])
+    |> shouldEqual(seq [ BookType.EBook; BookType.Paperback ])
+
+    defaultParseModel<int option array>(indexedData [ "1"; "2" ])
+    |> shouldEqual [| Some 1; Some 2 |]
+
+    defaultParseModel<Nullable<int> array>(indexedData [ "1"; "2" ])
+    |> shouldEqual [| Nullable 1; Nullable 2 |]
+
+    defaultParseModel<Sex array>(indexedData [ "Female"; "Male" ])
+    |> shouldEqual [| Female; Male |]
+
+[<Fact>]
 let ``defaultParseModel<BookType> parses a valid enum value 'Paperback'`` () =
     let modelData = "Paperback" |> StringValues |> SimpleData
     let expected = BookType.Paperback

--- a/tests/Oxpecker.Tests/ModelParser.Tests.fs
+++ b/tests/Oxpecker.Tests/ModelParser.Tests.fs
@@ -102,6 +102,21 @@ let ``parseModel<Model2> handles multi-element string array`` () =
     result |> shouldEqual expected
 
 [<Fact>]
+let ``parseModel<Model2> handles indexed string array`` () =
+    let modelData =
+        [
+            "SearchTerms[2]", StringValues "abcdef"
+            "SearchTerms[0]", StringValues "a"
+            "SearchTerms[1]", StringValues "abc"
+        ]
+        |> toComplexData
+    let expected = {
+        SearchTerms = [| "a"; "abc"; "abcdef" |]
+    }
+    let result = defaultParseModel<Model2> modelData
+    result |> shouldEqual expected
+
+[<Fact>]
 let ``defaultParseModel<Model> parses complete model data correctly`` () =
     let id = Guid.NewGuid()
     let modelData =
@@ -838,6 +853,13 @@ let ``parseModel throws when collection index reaches MaxCollectionSize`` () =
     result |> shouldFail<MaxCollectionSizeExceededException>
 
 [<Fact>]
+let ``parseModel throws when indexed string collection reaches MaxCollectionSize`` () =
+    let modelData = [ "SearchTerms[1024]", StringValues "x" ] |> toComplexData
+    let result () =
+        defaultParseModel<Model2> modelData |> ignore
+    result |> shouldFail<MaxCollectionSizeExceededException>
+
+[<Fact>]
 let ``parseModel binds collection index just below MaxCollectionSize`` () =
     let modelData =
         [
@@ -889,10 +911,7 @@ let ``parseModel does not throw on unterminated property`` () =
 [<Fact>]
 let ``parseModel binds collection with single-character subkey`` () =
     let modelData =
-        [
-            "Points[0].X", StringValues "1"
-            "Points[1].X", StringValues "2"
-        ]
+        [ "Points[0].X", StringValues "1"; "Points[1].X", StringValues "2" ]
         |> toComplexData
     let expected = {
         Points = [| { X = 1; Y = 0 }; { X = 2; Y = 0 } |]

--- a/tests/Oxpecker.Tests/ModelParser.Tests.fs
+++ b/tests/Oxpecker.Tests/ModelParser.Tests.fs
@@ -40,6 +40,10 @@ type CompositeModel = {
     SecondChild: Child option
 }
 
+type Point = { X: int; Y: int }
+
+type PointsModel = { Points: Point[] }
+
 [<Fact>]
 let ``parseModel<Model2> returns empty array for null SearchTerms`` () =
     let modelData =
@@ -881,3 +885,17 @@ let ``parseModel does not throw on unterminated property`` () =
     let modelData = [ "Children[5].", StringValues "x" ] |> toComplexData
     let result = defaultParseModel<Model> modelData
     result.Children |> shouldEqual [||]
+
+[<Fact>]
+let ``parseModel binds collection with single-character subkey`` () =
+    let modelData =
+        [
+            "Points[0].X", StringValues "1"
+            "Points[1].X", StringValues "2"
+        ]
+        |> toComplexData
+    let expected = {
+        Points = [| { X = 1; Y = 0 }; { X = 2; Y = 0 } |]
+    }
+    let result = defaultParseModel<PointsModel> modelData
+    result |> shouldEqual expected


### PR DESCRIPTION
The array index in indexed collection keys (e.g. "Items[N].Field") comes straight from the untrusted request key and was used directly to size a ResizeArray, with no upper bound. A single small request such as "Children[2000000000].Name=x" via BindForm/BindQuery could drive an allocation toward ~2 billion elements and OOM the worker.

Additionally the index parser threw on malformed keys (IndexOutOfRange for "[", "[5]"; OverflowException for indices above Int32.MaxValue), turning crafted keys into unhandled 500s.

- Add ModelBinderOptions.MaxCollectionSize (default 1024, matching ASP.NET Core's MaxModelBindingCollectionSize). A well-formed index that reaches or exceeds it (or overflows Int32) now raises MaxCollectionSizeExceededException instead of allocating, giving an explicit failure rather than silent data loss.
- Bounds-check all span accesses so genuinely malformed keys ("[", "[5]") fail the match and are ignored rather than throwing IndexOutOfRange.